### PR TITLE
V3: set viewtype in context

### DIFF
--- a/docs/pages/search-ui/viewtype.mdx
+++ b/docs/pages/search-ui/viewtype.mdx
@@ -28,14 +28,14 @@ function Example() {
   const variables = new Variables();
 
   const SearchPlayground = React.memo(() => {
-    const [type, setType] = React.useState('list');
+    const { results } = useSearch();
 
     return (
       <div className="flex flex-col space-y-4">
         <div>
-          <ViewType onChange={setType} />
+          <ViewType />
         </div>
-        <Results appearance={type} />
+        {results ? <Results /> : null}
       </div>
     );
   });
@@ -59,8 +59,6 @@ function Example() {
 
 ## Props
 
-| Name          | Type                                 | Default    | Description |
-| ------------- | ------------------------------------ | ---------- | ----------- |
-| `label`       | `string`                             | `"View"`   |             |
-| `defaultView` | `"list"` \| `"grid"`                 | `"list"`   |             |
-| `onChange`    | `(type: "list"` \| `"grid") => void` | `() => {}` |             |
+| Name    | Type     | Default  | Description |
+| ------- | -------- | -------- | ----------- |
+| `label` | `string` | `"View"` |             |

--- a/packages/hooks/src/SearchContextProvider/index.tsx
+++ b/packages/hooks/src/SearchContextProvider/index.tsx
@@ -24,6 +24,7 @@ import {
   PipelineProviderState,
   ProviderPipelineConfig,
   ProviderPipelineState,
+  ResultViewType,
   SearchProviderValues,
 } from './types';
 
@@ -81,6 +82,7 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
   const [instantSearching, setInstantSearching] = useState(false);
   const [searchState, setSearchState] = useState(defaultState);
   const [instantState, setInstantState] = useState(defaultState);
+  const [viewType, setViewType] = useState<ResultViewType>('list');
   const instant = useRef(instantProp);
   const response = search.pipeline.getResponse();
 
@@ -263,6 +265,8 @@ const SearchContextProvider: React.FC<SearchProviderValues> = ({
       },
       resultClicked: handleResultClicked,
       paginate: handlePaginate,
+      viewType,
+      setViewType,
     } as Context);
 
   return <Provider value={getContext({ instant: instantState, search: searchState })}>{children}</Provider>;

--- a/packages/hooks/src/SearchContextProvider/types.ts
+++ b/packages/hooks/src/SearchContextProvider/types.ts
@@ -5,6 +5,7 @@ export type SearchFn = (query?: string, override?: boolean) => void;
 export type ClearFn = (variables?: { [k: string]: string | undefined }) => void;
 export type ResultClickedFn = (url: string) => void;
 export type PaginateFn = (page: number) => void;
+export type ResultViewType = 'grid' | 'list';
 
 export interface PipelineContextState {
   variables: Variables;
@@ -53,6 +54,8 @@ export interface Context {
   instant: PipelineContextState;
   resultClicked: ResultClickedFn;
   paginate: PaginateFn;
+  setViewType: (v: ResultViewType) => void;
+  viewType: ResultViewType;
 }
 
 type Field = ((data: Record<string, any>) => any) | string | string[];

--- a/packages/hooks/src/useSearchContext/index.ts
+++ b/packages/hooks/src/useSearchContext/index.ts
@@ -6,6 +6,8 @@ import mapToObject from '../utils/mapToObject';
 function useSearchContext<T = Record<string, string | string[]>>() {
   const {
     search: { response, search, fields = {}, searching },
+    viewType,
+    setViewType,
   } = useContext();
   const { page, pageSize, totalResults, pageCount, setPage } = usePagination('search');
   const mapResponse = mapToObject(response?.getResponse() as Map<string, any> | undefined);
@@ -23,6 +25,8 @@ function useSearchContext<T = Record<string, string | string[]>>() {
     results: reqResults ? mapResultFields<T>(reqResults, fields) : undefined,
     response: mapResponse,
     searching,
+    viewType,
+    setViewType,
   };
 }
 

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -10,8 +10,8 @@ import useResultsStyles from './styles';
 import { ResultsProps, ResultValues } from './types';
 
 const Results = (props: ResultsProps) => {
-  const { appearance = 'list', className, ...rest } = props;
-  const { results } = useSearchContext<ResultValues>();
+  const { results, viewType } = useSearchContext<ResultValues>();
+  const { appearance = viewType, className, ...rest } = props;
   const [width, setWidth] = useState(0);
   const styles = useResultsStyles({ ...props, width });
   const setDebounced = useDebounce(setWidth, 50);

--- a/packages/search-ui/src/ViewType/index.tsx
+++ b/packages/search-ui/src/ViewType/index.tsx
@@ -2,30 +2,28 @@
 import { css, jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
 import { Button, ButtonGroup, Label } from '@sajari/react-components';
+import { useSearchContext } from '@sajari/react-hooks';
 import { __DEV__ } from '@sajari/react-sdk-utils';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import tw from 'twin.macro';
 
 import { IconSmallGrid, IconSmallList } from '../assets/icons';
-import { ListViewType, ViewTypeProps } from './types';
+import { ViewTypeProps } from './types';
 
 const styles = [tw`transition-colors duration-300 ease-out fill-current`];
 
-const ViewType: React.FC<ViewTypeProps> = ({ defaultView = 'list', label = 'View', onChange = () => {} }) => {
-  const [type, setType] = useState<ListViewType>(defaultView);
+const ViewType: React.FC<ViewTypeProps> = ({ label = 'View' }) => {
   const id = `view-type-${useId()}`;
-  useEffect(() => {
-    onChange(type);
-  }, [type]);
+  const { viewType, setViewType } = useSearchContext();
   return (
     <div css={tw`flex space-x-4`}>
       <Label htmlFor={id}>{label}</Label>
       <ButtonGroup id={id} attached>
-        <Button onClick={() => setType('grid')} appearance={type === 'grid' ? 'primary' : undefined}>
-          <IconSmallGrid css={css([...styles, ...(type === 'grid' ? [tw`text-white`] : [])])} />
+        <Button onClick={() => setViewType('grid')} appearance={viewType === 'grid' ? 'primary' : undefined}>
+          <IconSmallGrid css={css([...styles, ...(viewType === 'grid' ? [tw`text-white`] : [])])} />
         </Button>
-        <Button onClick={() => setType('list')} appearance={type === 'list' ? 'primary' : undefined}>
-          <IconSmallList css={css([...styles, ...(type === 'list' ? [tw`text-white`] : [])])} />
+        <Button onClick={() => setViewType('list')} appearance={viewType === 'list' ? 'primary' : undefined}>
+          <IconSmallList css={css([...styles, ...(viewType === 'list' ? [tw`text-white`] : [])])} />
         </Button>
       </ButtonGroup>
     </div>

--- a/packages/search-ui/src/ViewType/types.ts
+++ b/packages/search-ui/src/ViewType/types.ts
@@ -1,7 +1,3 @@
-export type ListViewType = 'list' | 'grid';
-
 export interface ViewTypeProps {
-  defaultView?: ListViewType;
   label?: string;
-  onChange?: (view: ListViewType) => void;
 }


### PR DESCRIPTION
## What this PR does
- [x] Add `viewType` state in the context
- [x] Hook `ViewType` up with context so it should just work without additional props
- [x] Make it so that `<Results />` can still control the appearance with prop