### PR TITLE
V3: fix searching state

### DIFF
--- a/packages/hooks/src/useAutocomplete/index.ts
+++ b/packages/hooks/src/useAutocomplete/index.ts
@@ -2,13 +2,14 @@ import { useContext } from '../SearchContextProvider';
 
 function useAutocomplete() {
   const {
-    instant: { suggestions, search, completion },
+    instant: { suggestions, search, completion, searching },
   } = useContext();
 
   return {
     suggestions,
     search,
     completion,
+    searching,
   };
 }
 


### PR DESCRIPTION
## Why
An oversight on my end, the `searching` state is modified even if it's just instant searching, there should be a separate state for it as well.
## What this PR does
- [x] Add another state `instantSearching` besides `searching`