### PR TITLE
V3: fix search on load

### DIFF
--- a/packages/hooks/src/SearchContextProvider/controllers/variables.ts
+++ b/packages/hooks/src/SearchContextProvider/controllers/variables.ts
@@ -22,7 +22,12 @@ export class Variables {
   constructor(variables: { [k: string]: string | string[] | number | boolean | VariableFn } = {}) {
     this.listeners = new Map([[EVENT_VALUES_UPDATED, new Listener()]]);
     this.variables = new Map(
-      Object.entries({ [defaultConfig.qParam]: '', [defaultConfig.resultsPerPageParam]: 15, ...variables }),
+      Object.entries({
+        [defaultConfig.qParam]: '',
+        [defaultConfig.resultsPerPageParam]: 15,
+        filter: 'id !== ""',
+        ...variables,
+      }),
     );
   }
 


### PR DESCRIPTION
## Why
When `searchOnLoad` is specified, it didn't seem to send any search request but in fact it did, it's just that the result came back as empty because the filter `_id != ""` was not present, read below on how this PR addresses that issue.

## What this PR does
- [x] Add additional `filter` field in `Variables` constructor