### PR TITLE
V3: add option to control styling of components

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/react-hooks": "^3.4.2",
+    "@types/classnames": "^2.2.11",
     "@types/color": "^3.0.1",
     "@types/jest": "^26.0.15",
     "@types/react": "^17.0.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,7 +34,6 @@
     "@react-aria/textfield": "^3.2.1",
     "@react-types/button": "^3.2.1",
     "@sajari/react-sdk-utils": "^1.0.0-alpha.13",
-    "@types/classnames": "^2.2.11",
     "classnames": "^2.2.6",
     "color": "^3.1.3",
     "downshift": "^6.0.6",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,6 +34,8 @@
     "@react-aria/textfield": "^3.2.1",
     "@react-types/button": "^3.2.1",
     "@sajari/react-sdk-utils": "^1.0.0-alpha.13",
+    "@types/classnames": "^2.2.11",
+    "classnames": "^2.2.6",
     "color": "^3.1.3",
     "downshift": "^6.0.6",
     "react-ranger": "^2.1.0",

--- a/packages/components/src/AspectRatio/index.tsx
+++ b/packages/components/src/AspectRatio/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { forwardRefWithAs, PropsWithAs } from '@sajari/react-sdk-utils';
+import { forwardRefWithAs, getStylesObject, PropsWithAs } from '@sajari/react-sdk-utils';
 import React, { Children, cloneElement, isValidElement } from 'react';
 
 import Box from '../Box';
@@ -10,7 +10,7 @@ import { AspectRatioProps } from './types';
 type DefaultElement = 'div';
 
 const Component = (props: PropsWithAs<AspectRatioProps, DefaultElement>, ref: React.Ref<HTMLDivElement>) => {
-  const { as = 'div', ratio = 16 / 9, children, ...rest } = props;
+  const { as = 'div', ratio = 16 / 9, children, disableDefaultStyles = false, styles: stylesProp, ...rest } = props;
   let child;
 
   if (children) {
@@ -21,10 +21,10 @@ const Component = (props: PropsWithAs<AspectRatioProps, DefaultElement>, ref: Re
     }
   }
 
-  const styles = useAspectRatioStyles({ ...props, ratio });
+  const styles = getStylesObject({ container: useAspectRatioStyles({ ...props, ratio }) }, disableDefaultStyles);
 
   return (
-    <Box ref={ref} as={as} {...rest} css={styles}>
+    <Box ref={ref} as={as} {...rest} css={[styles.container, stylesProp]}>
       {child ? cloneElement(child) : null}
     </Box>
   );

--- a/packages/components/src/AspectRatio/index.tsx
+++ b/packages/components/src/AspectRatio/index.tsx
@@ -14,7 +14,7 @@ const Component = (props: PropsWithAs<AspectRatioProps, DefaultElement>, ref: Re
   let child;
 
   if (children) {
-    child = Children.only<React.ReactChild>(children);
+    child = Children.only(children);
 
     if (!isValidElement(child)) {
       return null;

--- a/packages/components/src/AspectRatio/types.ts
+++ b/packages/components/src/AspectRatio/types.ts
@@ -1,6 +1,8 @@
 import { PropsWithAs } from '@sajari/react-sdk-utils';
 
-export interface Props {
+import { BoxProps } from '../Box';
+
+export interface Props extends Omit<BoxProps, 'children'> {
   /** The aspect ratio of the Box. Common values are:
    * `21/9`, `16/9`, `9/16`, `4/3`, `1.85/1` */
   ratio?: number | null;

--- a/packages/components/src/AspectRatio/types.ts
+++ b/packages/components/src/AspectRatio/types.ts
@@ -2,7 +2,7 @@ import { PropsWithAs } from '@sajari/react-sdk-utils';
 
 import { BoxProps } from '../Box';
 
-export interface Props extends Omit<BoxProps, 'children'> {
+export interface Props extends BoxProps {
   /** The aspect ratio of the Box. Common values are:
    * `21/9`, `16/9`, `9/16`, `4/3`, `1.85/1` */
   ratio?: number | null;

--- a/packages/components/src/Box/types.ts
+++ b/packages/components/src/Box/types.ts
@@ -1,4 +1,9 @@
+import { CSSObject } from '@emotion/core';
+
 export interface BoxProps {
   children?: React.ReactNode;
   className?: string;
+  styles?: CSSObject;
+  /** If true, the default styling will be disabled */
+  disableDefaultStyles?: boolean;
 }

--- a/packages/components/src/Button/index.tsx
+++ b/packages/components/src/Button/index.tsx
@@ -3,7 +3,8 @@ import { jsx } from '@emotion/core';
 import { useButton } from '@react-aria/button';
 import { useFocus, useHover } from '@react-aria/interactions';
 import { mergeProps } from '@react-aria/utils';
-import { mergeRefs } from '@sajari/react-sdk-utils';
+import { getStylesObject, mergeRefs } from '@sajari/react-sdk-utils';
+import classnames from 'classnames';
 import React, { useRef } from 'react';
 
 import Box from '../Box';
@@ -22,6 +23,10 @@ const Button = React.forwardRef((props: ButtonProps, ref?: React.Ref<HTMLElement
     fullWidth = false,
     onClick,
     children,
+    className,
+    styles: stylesProps,
+    pressedClassName = '',
+    disableDefaultStyles = false,
     ...rest
   } = props;
 
@@ -42,7 +47,7 @@ const Button = React.forwardRef((props: ButtonProps, ref?: React.Ref<HTMLElement
     onBlur: () => setFocused(false),
   });
 
-  const { styles, focusRingProps } = useButtonStyles({
+  const { styles: containerStyles, focusRingProps } = useButtonStyles({
     pressed,
     appearance,
     disabled,
@@ -55,12 +60,18 @@ const Button = React.forwardRef((props: ButtonProps, ref?: React.Ref<HTMLElement
   });
 
   const customProps = mergeProps(buttonProps, focusProps, hoverProps, focusRingProps);
+  const styles = getStylesObject({ container: containerStyles }, disableDefaultStyles);
 
-  // TODO: we want to toggle CSS classes based on the state change, for example
-  // {'sj-button--hovered': hovered, 'sj-button--focused': focused}
-  // but hold off since we're planning to put those classes in a upper ContextProvider
   return (
-    <Box as={as} ref={ownRef} {...customProps} css={styles}>
+    <Box
+      as={as}
+      ref={ownRef}
+      {...customProps}
+      css={[styles.container, stylesProps]}
+      className={classnames(className, {
+        [pressedClassName]: pressed,
+      })}
+    >
       {children}
     </Box>
   );

--- a/packages/components/src/Button/types.ts
+++ b/packages/components/src/Button/types.ts
@@ -1,11 +1,13 @@
 import { AriaButtonProps } from '@react-types/button';
 import { PropsWithAs } from '@sajari/react-sdk-utils';
 
+import { BoxProps } from '../Box';
+
 export type ButtonAppearance = 'default' | 'primary' | 'link' | 'subtle-link' | 'none';
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type ButtonSpacing = 'compact' | 'default' | 'none';
 
-interface Props {
+interface Props extends BoxProps {
   /** The base styling to apply to the button */
   appearance?: ButtonAppearance;
   /** Set how much spacing the button should have */
@@ -16,6 +18,8 @@ interface Props {
   loading?: boolean;
   /** Set if the button should be full width */
   fullWidth?: boolean;
+  /** The classname for pressed button */
+  pressedClassName?: string;
 }
 
 export interface ButtonProps extends PropsWithAs<Props>, AriaButtonProps {}

--- a/packages/components/src/ButtonGroup/index.tsx
+++ b/packages/components/src/ButtonGroup/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { __DEV__, cleanChildren } from '@sajari/react-sdk-utils';
+import { __DEV__, cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement } from 'react';
 import tw, { styled } from 'twin.macro';
 
@@ -41,20 +41,38 @@ const StyledBox = styled<any>(Box, { shouldForwardProp: (prop) => prop !== 'atta
 `;
 
 const ButtonGroup = React.forwardRef((props: ButtonGroupProps, ref?: React.Ref<HTMLDivElement>) => {
-  const { attached = false, fullWidth, inline = true, children, as = 'div', ...rest } = props;
-  const buttonGroupStyles = useButtonGroupStyles({ attached, inline });
+  const {
+    attached = false,
+    fullWidth,
+    inline = true,
+    children,
+    as = 'div',
+    disableDefaultStyles = false,
+    styles: stylesProp,
+    ...rest
+  } = props;
+  const styles = getStylesObject({ container: useButtonGroupStyles({ attached, inline }) }, disableDefaultStyles);
   const validChildren = cleanChildren(children);
 
   // TODO: handle case where child is Tooltip
   const clones = validChildren.map((child) =>
     cloneElement(child, {
       fullWidth,
+      disableDefaultStyles,
       ...child.props,
     }),
   );
 
+  if (disableDefaultStyles) {
+    return (
+      <Box as={as} ref={ref} css={stylesProp} {...rest}>
+        {clones}
+      </Box>
+    );
+  }
+
   return (
-    <StyledBox attached={attached} inline={inline} as={as} ref={ref} css={buttonGroupStyles} {...rest}>
+    <StyledBox attached={attached} inline={inline} as={as} ref={ref} css={[styles.container, stylesProp]} {...rest}>
       {clones}
     </StyledBox>
   );

--- a/packages/components/src/ButtonGroup/types.ts
+++ b/packages/components/src/ButtonGroup/types.ts
@@ -1,7 +1,9 @@
 import { PropsWithAs } from '@sajari/react-sdk-utils';
 import React from 'react';
 
-export interface Props {
+import { BoxProps } from '../Box';
+
+export interface Props extends BoxProps {
   /** Should the children be attached to each other */
   attached?: boolean;
   /** Make children fullWidth */

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,13 +1,13 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
-import { __DEV__, useTheme } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
-import tw from 'twin.macro';
 
 import Box from '../Box';
 import { UseInputStyleProps, useInputStyles } from '../hooks';
 import Label from '../Label';
+import { useCheckboxStyles } from './styles';
 import { CheckboxProps } from './types';
 
 const Checkbox = React.forwardRef((props: CheckboxProps, ref?: React.Ref<HTMLInputElement>) => {
@@ -27,24 +27,27 @@ const Checkbox = React.forwardRef((props: CheckboxProps, ref?: React.Ref<HTMLInp
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
     children,
+    labelClassName,
+    styles: stylesProp,
+    disableDefaultStyles = false,
     ...rest
   } = props;
-  const theme = useTheme();
 
-  // TODO: Should return all required styles
-  const { styles, focusRingStyles, focusProps } = useInputStyles({
+  const styles = getStylesObject(useCheckboxStyles(props), disableDefaultStyles);
+
+  const { focusProps } = useInputStyles({
     type: 'checkbox',
     indeterminate,
     ...props,
   } as UseInputStyleProps);
 
   const comp = (
-    <Box css={tw`relative inline-flex items-center`} {...(!children ? rest : {})}>
+    <Box css={[styles.componentWrapper, !children && stylesProp]} {...(!children ? rest : {})}>
       &#8203;
-      <Box as="span" css={[tw`relative flex`, focusRingStyles]}>
+      <Box as="span" css={styles.inputWrapper}>
         {indeterminate && (
-          <Box css={tw`absolute inset-0 flex items-center justify-center`}>
-            <Box css={[tw`m-auto w-1/2 h-0.5 rounded-sm`, { backgroundColor: theme.color.primary.text }]} />
+          <Box css={styles.indeterminate}>
+            <Box css={styles.indeterminateInner} />
           </Box>
         )}
         <input
@@ -63,7 +66,7 @@ const Checkbox = React.forwardRef((props: CheckboxProps, ref?: React.Ref<HTMLInp
           aria-invalid={invalid}
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
-          css={[tw`form-checkbox`, styles]}
+          css={styles.input}
           {...focusProps}
         />
       </Box>
@@ -75,10 +78,10 @@ const Checkbox = React.forwardRef((props: CheckboxProps, ref?: React.Ref<HTMLInp
   }
 
   return (
-    <Box css={tw`flex items-center`} {...rest}>
+    <Box css={[styles.container, stylesProp]} {...rest}>
       {comp}
 
-      <Label htmlFor={id} css={[tw`ml-2`, invalid ? tw`text-red-500` : []]}>
+      <Label htmlFor={id} css={styles.label} className={labelClassName}>
         {children}
       </Label>
     </Box>

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -5,7 +5,6 @@ import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 
 import Box from '../Box';
-import { UseInputStyleProps, useInputStyles } from '../hooks';
 import Label from '../Label';
 import { useCheckboxStyles } from './styles';
 import { CheckboxProps } from './types';
@@ -33,13 +32,8 @@ const Checkbox = React.forwardRef((props: CheckboxProps, ref?: React.Ref<HTMLInp
     ...rest
   } = props;
 
-  const styles = getStylesObject(useCheckboxStyles(props), disableDefaultStyles);
-
-  const { focusProps } = useInputStyles({
-    type: 'checkbox',
-    indeterminate,
-    ...props,
-  } as UseInputStyleProps);
+  const { styles: checkboxStyles, focusProps } = useCheckboxStyles(props);
+  const styles = getStylesObject(checkboxStyles, disableDefaultStyles);
 
   const comp = (
     <Box css={[styles.componentWrapper, !children && stylesProp]} {...(!children ? rest : {})}>

--- a/packages/components/src/Checkbox/styles.ts
+++ b/packages/components/src/Checkbox/styles.ts
@@ -1,0 +1,32 @@
+import { mapStyles, useTheme } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { UseInputStyleProps, useInputStyles } from '../hooks';
+import { CheckboxProps } from './types';
+
+export function useCheckboxStyles(props: CheckboxProps) {
+  const theme = useTheme();
+  const { invalid = false, indeterminate = false } = props;
+
+  const { styles: inputStyles, focusRingStyles } = useInputStyles({
+    type: 'checkbox',
+    indeterminate,
+    ...props,
+  } as UseInputStyleProps);
+
+  const styles = {
+    container: [tw`flex items-center`],
+    componentWrapper: [tw`relative inline-flex items-center`],
+    inputWrapper: [tw`relative flex`, focusRingStyles],
+    label: [tw`ml-2`],
+    indeterminate: [tw`absolute inset-0 flex items-center justify-center`],
+    indeterminateInner: [tw`m-auto w-1/2 h-0.5 rounded-sm`, { backgroundColor: theme.color.primary.text }],
+    input: [tw`form-checkbox`, inputStyles],
+  };
+
+  if (invalid) {
+    styles.label.push(tw`text-red-500`);
+  }
+
+  return mapStyles(styles);
+}

--- a/packages/components/src/Checkbox/styles.ts
+++ b/packages/components/src/Checkbox/styles.ts
@@ -8,7 +8,7 @@ export function useCheckboxStyles(props: CheckboxProps) {
   const theme = useTheme();
   const { invalid = false, indeterminate = false } = props;
 
-  const { styles: inputStyles, focusRingStyles } = useInputStyles({
+  const { styles: inputStyles, focusRingStyles, focusProps } = useInputStyles({
     type: 'checkbox',
     indeterminate,
     ...props,
@@ -28,5 +28,5 @@ export function useCheckboxStyles(props: CheckboxProps) {
     styles.label.push(tw`text-red-500`);
   }
 
-  return mapStyles(styles);
+  return { styles: mapStyles(styles), focusProps };
 }

--- a/packages/components/src/Checkbox/types.ts
+++ b/packages/components/src/Checkbox/types.ts
@@ -1,10 +1,14 @@
 import React from 'react';
 
-interface Props {
+import { BoxProps } from '../Box';
+
+interface Props extends BoxProps {
   /** The state when entering an invalid input */
   invalid?: boolean;
   /** Indeterminate state  */
   indeterminate?: boolean;
+  /** The classname for label */
+  labelClassName?: string;
 }
 
 export interface CheckboxProps extends Props, React.InputHTMLAttributes<HTMLInputElement> {}

--- a/packages/components/src/CheckboxGroup/index.tsx
+++ b/packages/components/src/CheckboxGroup/index.tsx
@@ -1,27 +1,28 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
-import { cleanChildren } from '@sajari/react-sdk-utils';
+import { cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement, useRef, useState } from 'react';
-import tw from 'twin.macro';
 
-import { useSpacing } from '../hooks';
+import { useCheckboxGroupStyles } from './styles';
 import { CheckboxGroupProps } from './types';
 
-const CheckboxGroup = ({
-  onChange,
-  name,
-  defaultValue,
-  inline,
-  value: valueProp,
-  spacing = inline ? '4' : '1',
-  children,
-  ...rest
-}: CheckboxGroupProps) => {
+const CheckboxGroup = (props: CheckboxGroupProps) => {
+  const {
+    onChange,
+    name,
+    defaultValue,
+    inline,
+    value: valueProp,
+    children,
+    styles: stylesProp,
+    disableDefaultStyles = false,
+    ...rest
+  } = props;
   const [values, setValues] = useState(defaultValue || []);
   const { current: isControlled } = useRef(valueProp != null);
   const internalValues = (isControlled ? valueProp : values) || [];
-  const spacingStyles = useSpacing({ spacing, inline });
+  const styles = getStylesObject(useCheckboxGroupStyles(props), disableDefaultStyles);
 
   const internalChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = event.target;
@@ -51,11 +52,12 @@ const CheckboxGroup = ({
       name: `${internalName}-${index}`,
       onChange: internalChange,
       checked: internalValues.includes(child.props.value),
+      disableDefaultStyles,
     }),
   );
 
   return (
-    <div {...rest} role="group" css={[tw`flex`, inline ? tw`flex-row` : tw`flex-col`, spacingStyles]}>
+    <div {...rest} role="group" css={[styles.container, stylesProp]}>
       {clones}
     </div>
   );

--- a/packages/components/src/CheckboxGroup/styles.ts
+++ b/packages/components/src/CheckboxGroup/styles.ts
@@ -1,0 +1,15 @@
+import { mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { useSpacing } from '../hooks';
+import { CheckboxGroupProps } from './types';
+
+export function useCheckboxGroupStyles(props: CheckboxGroupProps) {
+  const { inline, spacing = inline ? '4' : '1' } = props;
+  const spacingStyles = useSpacing({ spacing, inline });
+  const styles = {
+    container: [tw`flex`, inline ? tw`flex-row` : tw`flex-col`, spacingStyles],
+  };
+
+  return mapStyles(styles);
+}

--- a/packages/components/src/CheckboxGroup/types.ts
+++ b/packages/components/src/CheckboxGroup/types.ts
@@ -1,9 +1,10 @@
 import { HTMLAttributes } from 'react';
 
+import { BoxProps } from '../Box';
 import { CheckboxProps } from '../Checkbox';
 import { Spacing } from '../hooks';
 
-export interface Props {
+export interface Props extends BoxProps {
   name?: string;
   defaultValue?: Array<CheckboxProps['value']>;
   value?: Array<CheckboxProps['value']>;

--- a/packages/components/src/Heading/index.tsx
+++ b/packages/components/src/Heading/index.tsx
@@ -1,10 +1,10 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { forwardRefWithAs, PropsWithAs } from '@sajari/react-sdk-utils';
+import { forwardRefWithAs, getStylesObject, PropsWithAs } from '@sajari/react-sdk-utils';
 import React from 'react';
 
 import Box from '../Box';
-import { TextSizes, useTextSize } from '../hooks';
+import { TextSizes } from '../hooks';
 import useHeadingStyles from './styles';
 import { HeadingElements, HeadingProps } from './types';
 
@@ -30,11 +30,17 @@ const mapElementToSize = (element: HeadingElements): TextSizes => {
 };
 
 const HeadingComponent = (props: PropsWithAs<HeadingProps, DefaultElement>, ref: React.Ref<HTMLHeadingElement>) => {
-  const { as = 'h1', size = mapElementToSize(as), truncate, ...rest } = props;
-  const styles = useHeadingStyles({ size, as, truncate });
-  const sizeStyles = useTextSize({ size });
+  const {
+    as = 'h1',
+    size = mapElementToSize(as),
+    truncate,
+    disableDefaultStyles = false,
+    styles: stylesProp,
+    ...rest
+  } = props;
+  const styles = getStylesObject(useHeadingStyles({ size, as, truncate }), disableDefaultStyles);
 
-  return <Box ref={ref} as={as} css={[styles, sizeStyles]} {...rest} />;
+  return <Box ref={ref} as={as} css={[styles.container]} {...rest} />;
 };
 
 const Heading = forwardRefWithAs<HeadingProps, DefaultElement>(HeadingComponent);

--- a/packages/components/src/Heading/styles.ts
+++ b/packages/components/src/Heading/styles.ts
@@ -1,7 +1,7 @@
-import { css } from '@emotion/core';
+import { mapStyles } from '@sajari/react-sdk-utils';
 import tw from 'twin.macro';
 
-import { TextSizes } from '../hooks';
+import { TextSizes, useTextSize } from '../hooks';
 import { mapTruncateValue } from '../utils/styles';
 import { HeadingElements } from './types';
 
@@ -13,17 +13,26 @@ interface UseHeadingStylesOptions {
 
 export default function useHeadingStyles(options: UseHeadingStylesOptions) {
   const { size, truncate = false } = options;
-  const styles = [tw`p-0 m-0`, mapTruncateValue(truncate), size === 'xs' ? tw`text-gray-400` : tw`text-gray-800`];
+  const sizeStyles = useTextSize({ size });
+
+  const styles = {
+    container: [
+      tw`p-0 m-0`,
+      mapTruncateValue(truncate),
+      size === 'xs' ? tw`text-gray-400` : tw`text-gray-800`,
+      sizeStyles,
+    ],
+  };
 
   if (size === 'xs') {
-    styles.push(tw`font-medium tracking-wide uppercase`);
+    styles.container.push(tw`font-medium tracking-wide uppercase`);
   } else {
-    styles.push(tw`font-semibold normal-case`);
+    styles.container.push(tw`font-semibold normal-case`);
   }
 
   if (size !== 'xs' && size !== 'sm' && size !== 'base') {
-    styles.push(tw`tracking-tight`);
+    styles.container.push(tw`tracking-tight`);
   }
 
-  return css(styles);
+  return mapStyles(styles);
 }

--- a/packages/components/src/Heading/types.ts
+++ b/packages/components/src/Heading/types.ts
@@ -1,10 +1,13 @@
 import { HTMLAttributes } from 'react';
 
+import { BoxProps } from '../Box';
 import { TextSizes } from '../hooks';
 
 export type HeadingElements = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
-export interface HeadingProps extends HTMLAttributes<HTMLHeadingElement> {
+export interface HeadingProps extends BoxProps, HTMLAttributes<HTMLHeadingElement> {
+  /** Set the element that the text should render as */
+  as?: HeadingElements;
   /** The size variant */
   size?: TextSizes;
   /** Whether to truncate the text. Specify a number will use line-clamp */

--- a/packages/components/src/Heading/types.ts
+++ b/packages/components/src/Heading/types.ts
@@ -6,8 +6,6 @@ import { TextSizes } from '../hooks';
 export type HeadingElements = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 export interface HeadingProps extends BoxProps, HTMLAttributes<HTMLHeadingElement> {
-  /** Set the element that the text should render as */
-  as?: HeadingElements;
   /** The size variant */
   size?: TextSizes;
   /** Whether to truncate the text. Specify a number will use line-clamp */

--- a/packages/components/src/Image/index.tsx
+++ b/packages/components/src/Image/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 
 import AspectRatio from '../AspectRatio';
@@ -22,13 +22,25 @@ const NativeImage = React.forwardRef((props: NativeImageProps, ref?: React.Ref<H
 });
 
 const Image = React.forwardRef((props: ImageProps, ref?: React.Ref<HTMLImageElement>) => {
-  const { src, onError, onLoad, htmlWidth, htmlHeight, aspectRatio, objectFit, ...rest } = props;
+  const {
+    src,
+    onError,
+    onLoad,
+    htmlWidth,
+    htmlHeight,
+    aspectRatio,
+    objectFit,
+    className,
+    containerClassName,
+    disableDefaultStyles = false,
+    ...rest
+  } = props;
   const imageProps = { src, onLoad, onError, htmlWidth, htmlHeight };
-  const styles = useImageStyles(props);
+  const styles = getStylesObject(useImageStyles(props), disableDefaultStyles);
   const image = <Box as={NativeImage} ref={ref} css={styles.image} {...imageProps} {...rest} />;
 
   return (
-    <AspectRatio ratio={aspectRatio ?? null} css={styles.container}>
+    <AspectRatio ratio={aspectRatio ?? null} css={styles.container} className={containerClassName}>
       {src ? image : null}
     </AspectRatio>
   );

--- a/packages/components/src/Image/types.ts
+++ b/packages/components/src/Image/types.ts
@@ -1,10 +1,11 @@
 import React from 'react';
 
 import { AspectRatioProps } from '../AspectRatio';
+import { BoxProps } from '../Box';
 
 type HtmlAttributes = Omit<React.ImgHTMLAttributes<HTMLImageElement>, keyof Props>;
 
-interface Props {
+interface Props extends BoxProps {
   /** The alt text that describes the image */
   alt?: string;
   /** The native HTML `width` attribute to the passed to the `img` */
@@ -17,6 +18,8 @@ interface Props {
   aspectRatio?: AspectRatioProps['ratio'];
   /** Handy for use with the aspectRatio option */
   objectFit?: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
+  /** The classname for  AspectRatio container wrapper */
+  containerClassName?: string;
 }
 
 export interface ImageProps extends HtmlAttributes, Props {}

--- a/packages/components/src/Label/index.tsx
+++ b/packages/components/src/Label/index.tsx
@@ -1,19 +1,18 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 
-import { useTextSize } from '../hooks';
+import Box from '../Box';
 import useLabelStyles from './styles';
 import { LabelProps } from './types';
 
 const Label = React.forwardRef((props: LabelProps, ref?: React.Ref<HTMLLabelElement>) => {
-  const { size } = props;
-  const styles = useLabelStyles(props);
-  const sizeStyles = useTextSize({ size });
+  const { disableDefaultStyles = false, visuallyHidden, styles: stylesProp, ...rest } = props;
+  const styles = getStylesObject(useLabelStyles(props), disableDefaultStyles && !visuallyHidden);
 
-  return <label {...props} ref={ref} css={[styles, sizeStyles]} />;
+  return <Box as="label" {...rest} ref={ref} css={[styles.container, stylesProp]} />;
 });
 
 if (__DEV__) {

--- a/packages/components/src/Label/styles.ts
+++ b/packages/components/src/Label/styles.ts
@@ -1,16 +1,21 @@
-import { css } from '@emotion/core';
+import { mapStyles } from '@sajari/react-sdk-utils';
 import tw, { TwStyle } from 'twin.macro';
 
+import { useTextSize } from '../hooks';
 import { LabelProps } from './types';
 
-export default function useLabelStyles({ visuallyHidden }: LabelProps) {
-  const styles: TwStyle[] = [];
+export default function useLabelStyles({ visuallyHidden, size }: LabelProps) {
+  const styles: Record<'container', TwStyle[]> = {
+    container: [],
+  };
 
   if (visuallyHidden) {
-    styles.push(tw`sr-only`);
+    styles.container.push(tw`sr-only`);
   } else {
-    styles.push(tw`inline-flex items-center cursor-pointer`);
+    const sizeStyles = useTextSize({ size });
+    styles.container.push(tw`inline-flex items-center cursor-pointer`);
+    styles.container.push(sizeStyles as any);
   }
 
-  return css(styles);
+  return mapStyles(styles);
 }

--- a/packages/components/src/Label/types.ts
+++ b/packages/components/src/Label/types.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 
+import { BoxProps } from '../Box';
 import { UseTextSizeParams } from '../hooks';
 
-interface Props {
+interface Props extends BoxProps {
   /** Visually hidden label */
   visuallyHidden?: boolean;
   /** The ID of the input associated to the label */

--- a/packages/components/src/Link/index.tsx
+++ b/packages/components/src/Link/index.tsx
@@ -2,28 +2,19 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { mergeProps } from '@react-aria/utils';
-import { __DEV__, useTheme } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
-import tw from 'twin.macro';
 
 import { useFocusRingStyles } from '../hooks';
+import useLinkStyles from './styles';
 import { LinkProps } from './types';
 
 const Link = React.forwardRef((props: LinkProps, ref?: React.Ref<HTMLAnchorElement>) => {
-  const { focusProps, focusRingStyles } = useFocusRingStyles();
-  const theme = useTheme();
+  const { focusProps } = useFocusRingStyles();
+  const { disableDefaultStyles = false, styles: stylesProp, ...rest } = props;
+  const styles = getStylesObject(useLinkStyles(), disableDefaultStyles);
 
-  return (
-    <a
-      {...mergeProps(props, focusProps)}
-      ref={ref}
-      css={[
-        tw`relative transition-colors duration-150`,
-        focusRingStyles,
-        `&:hover, &:focus { color: ${theme.color.primary.base} }`,
-      ]}
-    />
-  );
+  return <a {...mergeProps(rest, focusProps)} ref={ref} css={[styles.container, stylesProp]} />;
 });
 
 if (__DEV__) {

--- a/packages/components/src/Link/styles.ts
+++ b/packages/components/src/Link/styles.ts
@@ -1,0 +1,19 @@
+import { mapStyles, useTheme } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { useFocusRingStyles } from '../hooks';
+
+export default function useLinkStyles() {
+  const theme = useTheme();
+  const { focusRingStyles } = useFocusRingStyles();
+
+  const styles = {
+    container: [
+      tw`relative transition-colors duration-150`,
+      focusRingStyles,
+      `&:hover, &:focus { color: ${theme.color.primary.base} }`,
+    ],
+  };
+
+  return mapStyles(styles);
+}

--- a/packages/components/src/Link/types.ts
+++ b/packages/components/src/Link/types.ts
@@ -1,3 +1,5 @@
 import React from 'react';
 
-export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {}
+import { BoxProps } from '../Box';
+
+export interface LinkProps extends BoxProps, React.AnchorHTMLAttributes<HTMLAnchorElement> {}

--- a/packages/components/src/Pagination/index.tsx
+++ b/packages/components/src/Pagination/index.tsx
@@ -29,13 +29,7 @@ const getButtons = (
   const limit = 5;
   const middle = Math.ceil(limit / 2);
   let offset = 0;
-  const {
-    activeClassName = '',
-    spacerEllipsisClassName,
-    buttonClassName,
-    disableDefaultStyles,
-    pressedClassName = '',
-  } = props;
+  const { activeClassName = '', spacerEllipsisClassName, buttonClassName, disableDefaultStyles } = props;
 
   if (pageCount > limit) {
     if (page < limit) {
@@ -98,7 +92,6 @@ const getButtons = (
         aria-current={active ? 'page' : undefined}
         aria-label={getLabel(number, active)}
         onClick={() => onChange && onChange(number)}
-        pressedClassName={pressedClassName}
         className={classnames(buttonClassName, { [activeClassName]: active })}
       >
         {number}
@@ -119,7 +112,6 @@ const Pagination = (props: PaginationProps) => {
     nextClassName,
     prevClassName,
     spacerEllipsisClassName,
-    pressedClassName,
     styles: stylesProp,
     disableDefaultStyles = false,
     ...rest
@@ -160,7 +152,6 @@ const Pagination = (props: PaginationProps) => {
         onClick={() => (hasPrevious ? changeHandler(page - 1) : {})}
         aria-label={i18n.previous}
         className={classnames(prevClassName, buttonClassName)}
-        pressedClassName={pressedClassName}
       >
         &#8203;
         <IconChevronLeft />
@@ -174,7 +165,6 @@ const Pagination = (props: PaginationProps) => {
         onClick={() => (hasNext ? changeHandler(page + 1) : {})}
         aria-label={i18n.next}
         className={classnames(nextClassName, buttonClassName)}
-        pressedClassName={pressedClassName}
       >
         &#8203;
         <IconChevronRight />

--- a/packages/components/src/Pagination/styles.ts
+++ b/packages/components/src/Pagination/styles.ts
@@ -1,0 +1,16 @@
+import { mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { useJustifyContent } from '../hooks';
+import { PaginationProps } from './types';
+
+export default function usePaginationStyles(props: PaginationProps) {
+  const { align = 'center' } = props;
+  const justifyContentStyles = useJustifyContent({ align });
+
+  const styles = {
+    container: [tw`flex`, justifyContentStyles],
+  };
+
+  return mapStyles(styles);
+}

--- a/packages/components/src/Pagination/types.ts
+++ b/packages/components/src/Pagination/types.ts
@@ -1,4 +1,7 @@
-export interface PaginationProps {
+import { BoxProps } from '../Box';
+import { ButtonProps } from '../Button';
+
+export interface PaginationProps extends BoxProps, Pick<ButtonProps, 'pressedClassName'> {
   /** The total number of pages */
   pageCount?: number;
   /** The total number of results (used to calculate page count if not set) */
@@ -19,4 +22,14 @@ export interface PaginationProps {
     page?: string;
     current?: string;
   };
+  /** The classname for button */
+  buttonClassName?: string;
+  /** The classname for next button */
+  nextClassName?: string;
+  /** The classname for previous button */
+  prevClassName?: string;
+  /** The classname for ellipsis spacer */
+  spacerEllipsisClassName?: string;
+  /** The classname for current page */
+  activeClassName?: string;
 }

--- a/packages/components/src/Pagination/types.ts
+++ b/packages/components/src/Pagination/types.ts
@@ -1,7 +1,6 @@
 import { BoxProps } from '../Box';
-import { ButtonProps } from '../Button';
 
-export interface PaginationProps extends BoxProps, Pick<ButtonProps, 'pressedClassName'> {
+export interface PaginationProps extends BoxProps {
   /** The total number of pages */
   pageCount?: number;
   /** The total number of results (used to calculate page count if not set) */

--- a/packages/components/src/PoweredBy/types.ts
+++ b/packages/components/src/PoweredBy/types.ts
@@ -1,6 +1,8 @@
 import React from 'react';
 
-interface Props {
+import { BoxProps } from '../Box';
+
+interface Props extends BoxProps {
   /** Which logo to use */
   appearance?: 'color' | 'mono';
 }

--- a/packages/components/src/Radio/index.tsx
+++ b/packages/components/src/Radio/index.tsx
@@ -6,7 +6,6 @@ import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 
 import Box from '../Box';
-import { UseInputStyleProps, useInputStyles } from '../hooks';
 import Label from '../Label';
 import useRadioStyles from './styles';
 import { RadioProps } from './types';
@@ -34,13 +33,8 @@ const Radio = React.forwardRef((props: RadioProps, ref?: React.Ref<HTMLInputElem
     ...rest
   } = props;
 
-  const styles = getStylesObject(useRadioStyles(props), disableDefaultStyles);
-
-  const { focusProps } = useInputStyles({
-    block: true,
-    type: 'radio',
-    ...props,
-  } as UseInputStyleProps);
+  const { styles: radioStyles, focusProps } = useRadioStyles(props);
+  const styles = getStylesObject(radioStyles, disableDefaultStyles);
 
   const comp = (
     <Box css={[styles.componentWrapper, !children && stylesProp]} {...(!children ? rest : {})}>

--- a/packages/components/src/Radio/index.tsx
+++ b/packages/components/src/Radio/index.tsx
@@ -2,13 +2,13 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
-import tw from 'twin.macro';
 
 import Box from '../Box';
 import { UseInputStyleProps, useInputStyles } from '../hooks';
 import Label from '../Label';
+import useRadioStyles from './styles';
 import { RadioProps } from './types';
 
 const Radio = React.forwardRef((props: RadioProps, ref?: React.Ref<HTMLInputElement>) => {
@@ -28,19 +28,24 @@ const Radio = React.forwardRef((props: RadioProps, ref?: React.Ref<HTMLInputElem
     onBlur,
     onFocus,
     children,
+    labelClassName,
+    styles: stylesProp,
+    disableDefaultStyles = false,
     ...rest
   } = props;
 
-  const { styles, focusRingStyles, focusProps } = useInputStyles({
+  const styles = getStylesObject(useRadioStyles(props), disableDefaultStyles);
+
+  const { focusProps } = useInputStyles({
     block: true,
     type: 'radio',
     ...props,
   } as UseInputStyleProps);
 
   const comp = (
-    <Box css={tw`inline-flex items-center`} {...(!children ? rest : {})}>
+    <Box css={[styles.componentWrapper, !children && stylesProp]} {...(!children ? rest : {})}>
       &#8203;
-      <Box as="span" css={[tw`relative`, focusRingStyles]}>
+      <Box as="span" css={styles.inputWrapper}>
         <input
           ref={ref}
           type="radio"
@@ -57,7 +62,7 @@ const Radio = React.forwardRef((props: RadioProps, ref?: React.Ref<HTMLInputElem
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledBy}
           aria-invalid={invalid}
-          css={[tw`form-radio`, styles]}
+          css={styles.input}
           {...focusProps}
         />
       </Box>
@@ -69,10 +74,10 @@ const Radio = React.forwardRef((props: RadioProps, ref?: React.Ref<HTMLInputElem
   }
 
   return (
-    <Box css={tw`flex items-center`} {...rest}>
+    <Box css={[styles.container, stylesProp]} {...rest}>
       {comp}
 
-      <Label htmlFor={id} css={[tw`ml-2`, invalid ? tw`text-red-500` : []]}>
+      <Label htmlFor={id} css={styles.label} className={labelClassName}>
         {children}
       </Label>
     </Box>

--- a/packages/components/src/Radio/styles.ts
+++ b/packages/components/src/Radio/styles.ts
@@ -1,0 +1,29 @@
+import { mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { UseInputStyleProps, useInputStyles } from '../hooks';
+import { RadioProps } from './types';
+
+export default function useRadioStyles(props: RadioProps) {
+  const { invalid = false } = props;
+
+  const { styles: inputStyles, focusRingStyles } = useInputStyles({
+    block: true,
+    type: 'radio',
+    ...props,
+  } as UseInputStyleProps);
+
+  const styles = {
+    container: [tw`flex items-center`],
+    label: [tw`ml-2`],
+    componentWrapper: [tw`inline-flex items-center`],
+    inputWrapper: [tw`relative`, focusRingStyles],
+    input: [[tw`form-radio`, inputStyles]],
+  };
+
+  if (invalid) {
+    styles.label.push(tw`text-red-500`);
+  }
+
+  return mapStyles(styles);
+}

--- a/packages/components/src/Radio/styles.ts
+++ b/packages/components/src/Radio/styles.ts
@@ -7,7 +7,7 @@ import { RadioProps } from './types';
 export default function useRadioStyles(props: RadioProps) {
   const { invalid = false } = props;
 
-  const { styles: inputStyles, focusRingStyles } = useInputStyles({
+  const { styles: inputStyles, focusRingStyles, focusProps } = useInputStyles({
     block: true,
     type: 'radio',
     ...props,
@@ -25,5 +25,5 @@ export default function useRadioStyles(props: RadioProps) {
     styles.label.push(tw`text-red-500`);
   }
 
-  return mapStyles(styles);
+  return { styles: mapStyles(styles), focusProps };
 }

--- a/packages/components/src/Radio/types.ts
+++ b/packages/components/src/Radio/types.ts
@@ -1,8 +1,11 @@
 import React from 'react';
 
-interface Props {
+import { BoxProps } from '../Box';
+
+interface Props extends BoxProps {
   /** The state when entering an invalid input */
   invalid?: boolean;
+  labelClassName?: string;
 }
 
 export interface RadioProps extends Props, React.InputHTMLAttributes<HTMLInputElement> {}

--- a/packages/components/src/RadioGroup/index.tsx
+++ b/packages/components/src/RadioGroup/index.tsx
@@ -1,87 +1,79 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
-import { cleanChildren } from '@sajari/react-sdk-utils';
+import { cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement, forwardRef, useImperativeHandle, useRef, useState } from 'react';
-import tw from 'twin.macro';
 
-import { useSpacing } from '../hooks';
+import useRadioGroupStyles from './styles';
 import { RadioGroupProps } from './types';
 
-const RadioGroup = forwardRef(
-  (
-    {
-      onChange,
-      name,
-      defaultValue,
-      inline = false,
-      value: valueProp,
-      spacing = inline ? '4' : '1',
-      children,
-      ...rest
-    }: RadioGroupProps,
+const RadioGroup = forwardRef((props: RadioGroupProps, ref) => {
+  const {
+    onChange,
+    name,
+    defaultValue,
+    value: valueProp,
+    children,
+    styles: stylesProp,
+    disableDefaultStyles = false,
+    ...rest
+  } = props;
+  const { current: isControlled } = useRef(valueProp != null);
+  const [value, setValue] = useState(defaultValue || null);
+  const internalValue = isControlled ? valueProp : value;
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  const internalOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (!isControlled) {
+      setValue(event.target.value);
+    }
+    if (onChange) {
+      onChange(event, event.target.value);
+    }
+  };
+
+  // If no name is passed, we'll generate a random, unique name
+  const fallbackName = `radio-${useId()}`;
+  const internalName = name || fallbackName;
+  const validChildren = cleanChildren(children);
+
+  const clones = validChildren.map((child, index) =>
+    cloneElement(child, {
+      key: `${internalName}-${index}`,
+      name: internalName,
+      onChange: internalOnChange,
+      checked: child.props.value === internalValue,
+      disableDefaultStyles,
+    }),
+  );
+
+  // Calling focus() on the radiogroup should focus on the selected option or first enabled option
+  useImperativeHandle(
     ref,
-  ) => {
-    const { current: isControlled } = useRef(valueProp != null);
-    const [value, setValue] = useState(defaultValue || null);
-    const internalValue = isControlled ? valueProp : value;
-    const spacingStyles = useSpacing({ spacing, inline });
-    const rootRef = useRef<HTMLDivElement | null>(null);
+    () => ({
+      focus: () => {
+        let input = rootRef?.current?.querySelector<HTMLDivElement>('input:not(:disabled):checked');
 
-    const internalOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (!isControlled) {
-        setValue(event.target.value);
-      }
-      if (onChange) {
-        onChange(event, event.target.value);
-      }
-    };
+        if (!input) {
+          input = rootRef?.current?.querySelector('input:not(:disabled)');
+        }
 
-    // If no name is passed, we'll generate a random, unique name
-    const fallbackName = `radio-${useId()}`;
-    const internalName = name || fallbackName;
-    const validChildren = cleanChildren(children);
+        if (input) {
+          input.focus();
+        }
+      },
+    }),
+    [],
+  );
 
-    const clones = validChildren.map((child, index) =>
-      cloneElement(child, {
-        key: `${internalName}-${index}`,
-        name: internalName,
-        onChange: internalOnChange,
-        checked: child.props.value === internalValue,
-      }),
-    );
+  const styles = getStylesObject(useRadioGroupStyles(props), disableDefaultStyles);
 
-    // Calling focus() on the radiogroup should focus on the selected option or first enabled option
-    useImperativeHandle(
-      ref,
-      () => ({
-        focus: () => {
-          let input = rootRef?.current?.querySelector<HTMLDivElement>('input:not(:disabled):checked');
-
-          if (!input) {
-            input = rootRef?.current?.querySelector('input:not(:disabled)');
-          }
-
-          if (input) {
-            input.focus();
-          }
-        },
-      }),
-      [],
-    );
-
-    return (
-      <div
-        {...rest}
-        ref={rootRef}
-        role="radiogroup"
-        css={[tw`flex`, inline ? tw`flex-row` : tw`flex-col`, spacingStyles]}
-      >
-        {clones}
-      </div>
-    );
-  },
-);
+  return (
+    <div {...rest} ref={rootRef} role="radiogroup" css={[styles.container, stylesProp]}>
+      {clones}
+    </div>
+  );
+});
 
 RadioGroup.displayName = 'RadioGroup';
 

--- a/packages/components/src/RadioGroup/styles.ts
+++ b/packages/components/src/RadioGroup/styles.ts
@@ -1,0 +1,15 @@
+import { mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { useSpacing } from '../hooks';
+import { RadioGroupProps } from './types';
+
+export default function useRadioGroupStyles(props: RadioGroupProps) {
+  const { inline = false, spacing = inline ? '4' : '1' } = props;
+  const spacingStyles = useSpacing({ spacing, inline });
+  const styles = {
+    container: [tw`flex`, inline ? tw`flex-row` : tw`flex-col`, spacingStyles],
+  };
+
+  return mapStyles(styles);
+}

--- a/packages/components/src/RadioGroup/types.ts
+++ b/packages/components/src/RadioGroup/types.ts
@@ -1,8 +1,9 @@
 import React from 'react';
 
+import { BoxProps } from '../Box';
 import { Spacing } from '../hooks';
 
-interface Props {
+interface Props extends BoxProps {
   name?: string;
   defaultValue?: string;
   value?: string;

--- a/packages/components/src/RangeInput/index.tsx
+++ b/packages/components/src/RangeInput/index.tsx
@@ -30,6 +30,11 @@ const RangeInput = React.forwardRef((props: RangeInputProps, ref?: React.Ref<HTM
     rightInput: rightInputFunc,
     showInputs = false,
     tick,
+    fillClassName,
+    handleClassName,
+    trackClassName,
+    inputClassName,
+    ...rest
   } = props;
   const isSingleHandle = value.length === 1;
   const [min, max] = filter?.limit() ?? [minProp, maxProp];
@@ -131,6 +136,7 @@ const RangeInput = React.forwardRef((props: RangeInputProps, ref?: React.Ref<HTM
 
   const leftInputProps = {
     ...inputProps,
+    className: inputClassName,
     value: low.toString(),
     onChange: handleRangeInputChange(true),
     label: 'Range input left bound',
@@ -138,6 +144,7 @@ const RangeInput = React.forwardRef((props: RangeInputProps, ref?: React.Ref<HTM
 
   const rightInputProps = {
     ...inputProps,
+    className: inputClassName,
     value: (isSingleHandle ? 0 : high).toString(),
     onChange: handleRangeInputChange(false),
     label: 'Range input right bound',
@@ -167,7 +174,7 @@ const RangeInput = React.forwardRef((props: RangeInputProps, ref?: React.Ref<HTM
   }
 
   return (
-    <Box ref={ref} css={tw`flex flex-col`}>
+    <Box ref={ref} css={tw`flex flex-col`} {...rest}>
       <Box css={tw`w-full mt-8 mb-3`}>
         <Box css={tw`relative`}>
           {ticks.map(({ value: tickValue, getTickProps }) => (
@@ -184,12 +191,13 @@ const RangeInput = React.forwardRef((props: RangeInputProps, ref?: React.Ref<HTM
           ))}
         </Box>
 
-        <Track {...getTrackProps({ ref: trackRef })}>
+        <Track {...getTrackProps({ ref: trackRef })} className={trackClassName}>
           {segments.map(({ getSegmentProps }, i: number) => (
             <Fill
               index={i}
               isSingleHandle={isSingleHandle}
               onClick={(e: MouseEvent<HTMLDivElement>) => handleSegmentClick(e, i)}
+              className={fillClassName}
               {...getSegmentProps()}
             />
           ))}

--- a/packages/components/src/RangeInput/types.ts
+++ b/packages/components/src/RangeInput/types.ts
@@ -2,13 +2,15 @@ import { AriaTextFieldOptions, TextFieldAria } from '@react-aria/textfield';
 import { Range, RangeFilter } from '@sajari/react-hooks';
 import React from 'react';
 
+import { BoxProps } from '../Box';
+
 export interface CustomInputProps {
   getProps: (
     override?: AriaTextFieldOptions,
   ) => TextFieldAria & { ref: React.MutableRefObject<HTMLInputElement | null> };
 }
 
-export interface RangeInputProps {
+export interface RangeInputProps extends BoxProps {
   /** The minimum permitted value */
   min?: number;
   /** The maximum permitted value */
@@ -35,4 +37,12 @@ export interface RangeInputProps {
   rightInput?: (props: CustomInputProps) => React.ReactNode;
   /** Show inputs */
   showInputs?: boolean;
+  /** The classname for track */
+  trackClassName?: string;
+  /** The classname for fill */
+  fillClassName?: string;
+  /** The classname for handle */
+  handleClassName?: string;
+  /** The classname for input */
+  inputClassName?: string;
 }

--- a/packages/components/src/Rating/RatingItem.tsx
+++ b/packages/components/src/Rating/RatingItem.tsx
@@ -3,6 +3,7 @@ import { jsx } from '@emotion/core';
 import React from 'react';
 import tw, { styled, theme } from 'twin.macro';
 
+import Box from '../Box';
 import { InternalRatingItemProps } from './types';
 
 const StyledFirstHalf = styled.div<{ half: boolean; flipped: boolean }>`
@@ -26,13 +27,16 @@ export const RatingItem = ({
   flipped = false,
   count,
   index,
+  styles: stylesProp,
+  ...rest
 }: InternalRatingItemProps) => {
   const characterNode = typeof character === 'function' ? character({ count, index }) : character;
 
   return (
-    <div
-      css={[tw`relative m-0 p-0 inline-block`, active && !half ? tw`text-orange-400` : tw`text-gray-300`]}
+    <Box
+      css={[tw`relative m-0 p-0 inline-block`, active && !half ? tw`text-orange-400` : tw`text-gray-300`, stylesProp]}
       aria-hidden
+      {...rest}
     >
       <div aria-setsize={count} aria-posinset={index + 1}>
         <StyledFirstHalf flipped={flipped} half={half}>
@@ -40,6 +44,6 @@ export const RatingItem = ({
         </StyledFirstHalf>
         <StyledSecondHalf>{characterNode}</StyledSecondHalf>
       </div>
-    </div>
+    </Box>
   );
 };

--- a/packages/components/src/Rating/index.tsx
+++ b/packages/components/src/Rating/index.tsx
@@ -2,6 +2,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { __DEV__ } from '@sajari/react-sdk-utils';
+import classnames from 'classnames';
 import React from 'react';
 import tw, { styled } from 'twin.macro';
 
@@ -18,7 +19,19 @@ const StyledBox = styled.div<{ flipped: boolean }>`
 `;
 
 const Rating = React.forwardRef((props: RatingProps, ref: React.Ref<HTMLDivElement>) => {
-  const { value, children, character = <IconSmallStar />, max = 5, direction = 'ltr', unit = 'star' } = props;
+  const {
+    value,
+    children,
+    character = <IconSmallStar />,
+    max = 5,
+    direction = 'ltr',
+    unit = 'star',
+    activeHalfRatingItemClassName,
+    activeRatingItemClassName,
+    ratingItemClassName,
+    styles: stylesProp,
+    ...rest
+  } = props;
 
   if (Number.isNaN(value)) {
     return null;
@@ -30,11 +43,20 @@ const Rating = React.forwardRef((props: RatingProps, ref: React.Ref<HTMLDivEleme
   const arr = toRatingArray(value, max);
 
   return (
-    <StyledBox flipped={flipped} ref={ref} role="img" aria-label={label}>
+    <StyledBox flipped={flipped} ref={ref} role="img" aria-label={label} css={stylesProp} {...rest}>
       {arr.map((type, i) => {
         switch (type) {
           case ItemType.Filled:
-            return <RatingItem key={`active-rating-${i}`} index={i} count={max} character={character} active />;
+            return (
+              <RatingItem
+                key={`active-rating-${i}`}
+                index={i}
+                count={max}
+                character={character}
+                className={classnames(ratingItemClassName, activeRatingItemClassName)}
+                active
+              />
+            );
 
           case ItemType.HalfFilled:
             return (
@@ -44,6 +66,7 @@ const Rating = React.forwardRef((props: RatingProps, ref: React.Ref<HTMLDivEleme
                 count={max}
                 flipped={flipped}
                 character={character}
+                className={classnames(ratingItemClassName, activeHalfRatingItemClassName)}
                 active
                 half
               />
@@ -51,7 +74,14 @@ const Rating = React.forwardRef((props: RatingProps, ref: React.Ref<HTMLDivEleme
 
           case ItemType.Empty:
             return (
-              <RatingItem key={`inactive-rating-${i}`} index={i} count={max} character={character} active={false} />
+              <RatingItem
+                key={`inactive-rating-${i}`}
+                index={i}
+                count={max}
+                character={character}
+                active={false}
+                className={ratingItemClassName}
+              />
             );
 
           default:

--- a/packages/components/src/Rating/types.ts
+++ b/packages/components/src/Rating/types.ts
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export interface RatingProps {
+import { BoxProps } from '../Box';
+
+export interface RatingProps extends BoxProps {
   /** The rating value, accepts decimal to represent half rating */
   value: number;
   /** Maxium level, used to fill in the empty stars */
@@ -13,9 +15,12 @@ export interface RatingProps {
   direction?: 'ltr' | 'rtl';
   /** Unit, used for labeling, default to "stars" */
   unit?: string;
+  ratingItemClassName?: string;
+  activeRatingItemClassName?: string;
+  activeHalfRatingItemClassName?: string;
 }
 
-export interface InternalRatingItemProps {
+export interface InternalRatingItemProps extends BoxProps {
   /** Index */
   index: number;
   /** Total count */

--- a/packages/components/src/Select/index.tsx
+++ b/packages/components/src/Select/index.tsx
@@ -1,26 +1,39 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
-import tw from 'twin.macro';
 
 import Box from '../Box';
 import { UseInputStyleProps, useInputStyles } from '../hooks';
 import Label from '../Label';
+import { useSelectStyles } from './styles';
 import { SelectProps } from './types';
 
 const Select = React.forwardRef((props: SelectProps, ref?: React.Ref<HTMLSelectElement>) => {
-  const { id = `select-${useId()}`, children, disabled, invalid, placeholder, label, size, ...rest } = props;
-  const { styles, focusRingStyles, focusProps } = useInputStyles({
+  const {
+    id = `select-${useId()}`,
+    children,
+    disabled,
+    invalid,
+    placeholder,
+    label,
+    size,
+    styles: stylesProp,
+    disableDefaultStyles = false,
+    ...rest
+  } = props;
+  const { focusProps } = useInputStyles({
     block: true,
     type: 'select',
     size,
     ...props,
   } as UseInputStyleProps);
 
+  const styles = getStylesObject(useSelectStyles(props), disableDefaultStyles);
+
   return (
-    <Box css={[tw`relative`, focusRingStyles]}>
+    <Box css={[styles.container, stylesProp]}>
       {label && (
         <Label visuallyHidden htmlFor={id}>
           {label}
@@ -34,7 +47,7 @@ const Select = React.forwardRef((props: SelectProps, ref?: React.Ref<HTMLSelectE
         dir="auto"
         disabled={disabled}
         aria-invalid={invalid}
-        css={[tw`form-select`, styles]}
+        css={styles.select}
         {...focusProps}
         {...rest}
       >

--- a/packages/components/src/Select/styles.ts
+++ b/packages/components/src/Select/styles.ts
@@ -1,0 +1,19 @@
+import { mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { UseInputStyleProps, useInputStyles } from '../hooks';
+import { SelectProps } from './types';
+
+export function useSelectStyles(props: SelectProps) {
+  const { styles: inputStyles, focusRingStyles } = useInputStyles({
+    type: 'select',
+    ...props,
+  } as UseInputStyleProps);
+
+  const styles = {
+    container: [tw`relative`, focusRingStyles],
+    select: [tw`form-select`, inputStyles],
+  };
+
+  return mapStyles(styles);
+}

--- a/packages/components/src/Select/types.ts
+++ b/packages/components/src/Select/types.ts
@@ -1,10 +1,11 @@
 import React from 'react';
 
+import { BoxProps } from '../Box';
 import { UseInputStyleProps } from '../hooks';
 
 type HtmlAttributes = Omit<React.SelectHTMLAttributes<HTMLSelectElement>, keyof Props | 'size'>;
 
-interface Props {
+interface Props extends BoxProps {
   /** The state when entering an invalid input */
   invalid?: boolean;
   /** An aria-label, also used for the placeholder if not specified */

--- a/packages/components/src/Spinner/index.tsx
+++ b/packages/components/src/Spinner/index.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { IconSpinner } from '../assets/icons';
 import { SpinnerProps } from './types';
 
-const Spinner = (props: SpinnerProps) => <IconSpinner {...props} />;
+const Spinner = ({ styles, ...props }: SpinnerProps) => <IconSpinner css={styles} {...props} />;
 
 if (__DEV__) {
   Spinner.displayName = 'Spinner';

--- a/packages/components/src/Spinner/types.ts
+++ b/packages/components/src/Spinner/types.ts
@@ -1,3 +1,5 @@
 import React from 'react';
 
-export interface SpinnerProps extends React.HTMLProps<SVGSVGElement> {}
+import { BoxProps } from '../Box';
+
+export interface SpinnerProps extends BoxProps, React.HTMLProps<SVGSVGElement> {}

--- a/packages/components/src/Swatch/color.tsx
+++ b/packages/components/src/Swatch/color.tsx
@@ -4,6 +4,7 @@ import { jsx } from '@emotion/core';
 import { useSwitch } from '@react-aria/switch';
 import { useToggleState } from '@react-stately/toggle';
 import { __DEV__ } from '@sajari/react-sdk-utils';
+import classnames from 'classnames';
 import ColorClass from 'color';
 import React, { useCallback } from 'react';
 import tw, { styled } from 'twin.macro';
@@ -53,6 +54,8 @@ export const Color = (props: ColorProps) => {
       : new ColorClass(bg).lightness(85).string(),
     border = new ColorClass(bg).darken(0.1).string(),
     rounded = 'md',
+    checkedClassName = '',
+    className,
   } = props;
   const ref = React.useRef<HTMLInputElement>(null);
   const { state, setState } = useSwatchContext();
@@ -75,7 +78,14 @@ export const Color = (props: ColorProps) => {
   const { focusProps, focusRingStyles } = useFocusRingStyles({ color: border.toString() });
 
   return (
-    <StyledLabel bg={bg} border={border} textColor={color} rounded={rounded} css={focusRingStyles}>
+    <StyledLabel
+      bg={bg}
+      border={border}
+      textColor={color}
+      rounded={rounded}
+      css={focusRingStyles}
+      className={classnames(className, { [checkedClassName]: checked })}
+    >
       <Box as="span" css={tw`sr-only`}>
         {id}
       </Box>

--- a/packages/components/src/Swatch/context.tsx
+++ b/packages/components/src/Swatch/context.tsx
@@ -3,6 +3,7 @@ import { createContext } from '@sajari/react-sdk-utils';
 interface SwatchContextProps {
   state: string[];
   setState: (checkedColors: string[]) => void;
+  disableDefaultStyles: boolean;
 }
 
 const [SwatchContextProvider, useSwatchContext] = createContext<SwatchContextProps>({

--- a/packages/components/src/Swatch/index.tsx
+++ b/packages/components/src/Swatch/index.tsx
@@ -9,9 +9,18 @@ import { colorKeys } from './colors';
 import SwatchContextProvider from './context';
 import { SwatchProps } from './types';
 
-const Swatch = ({ children, checkedColors = [], onChange = () => {} }: SwatchProps) => (
-  <SwatchContextProvider value={{ state: checkedColors, setState: onChange }}>
-    <Box css={tw`flex flex-wrap -mt-2 -ml-2`}>{children}</Box>
+const Swatch = ({
+  children,
+  checkedColors = [],
+  onChange = () => {},
+  disableDefaultStyles = false,
+  styles: stylesProp,
+  ...rest
+}: SwatchProps) => (
+  <SwatchContextProvider value={{ state: checkedColors, setState: onChange, disableDefaultStyles }}>
+    <Box css={[tw`flex flex-wrap -mt-2 -ml-2`, stylesProp]} {...rest}>
+      {children}
+    </Box>
   </SwatchContextProvider>
 );
 

--- a/packages/components/src/Swatch/types.ts
+++ b/packages/components/src/Swatch/types.ts
@@ -1,20 +1,23 @@
 import React from 'react';
-import { ThemeStyle } from 'twin.macro';
 
-export interface ColorProps {
+import { BoxProps } from '../Box';
+
+export interface ColorProps extends BoxProps {
   /** The identifier of the color */
   id: string;
   /** Background color */
-  bg: string | ThemeStyle;
+  bg: string;
   /** Check icon color */
-  color?: string | ThemeStyle;
+  color?: string;
   /** Border color, defaults to background color */
-  border?: string | ThemeStyle;
+  border?: string;
   /** Border radius */
   rounded?: 'sm' | 'md' | 'lg' | 'full' | 'none';
+  /** The classname for the color box being checked */
+  checkedClassName?: string;
 }
 
-export interface SwatchProps {
+export interface SwatchProps extends BoxProps {
   /** List of <Swatch.Color /> */
   children: React.ReactNode;
   /** On change handler */

--- a/packages/components/src/Tabs/Tab/index.tsx
+++ b/packages/components/src/Tabs/Tab/index.tsx
@@ -1,16 +1,20 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { mergeProps } from '@react-aria/utils';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
+import classnames from 'classnames';
 import React from 'react';
 
 import Box from '../../Box';
+import { useTabContext } from '../context';
 import useTabStyles from './styles';
 import { TabProps } from './types';
 
 const Tab = React.forwardRef((props: TabProps, ref?: React.Ref<HTMLButtonElement>) => {
-  const { selected, disabled, id, ...rest } = props;
-  const { styles, focusRingProps } = useTabStyles(props);
+  const { selected, disabled, id, className, selectedClassName = '', ...rest } = props;
+  const { disableDefaultStyles = false } = useTabContext();
+  const { styles: containerStyles, focusRingProps } = useTabStyles(props);
+  const styles = getStylesObject({ container: containerStyles }, disableDefaultStyles);
 
   return (
     <Box
@@ -24,7 +28,8 @@ const Tab = React.forwardRef((props: TabProps, ref?: React.Ref<HTMLButtonElement
       aria-selected={selected}
       aria-disabled={disabled}
       aria-controls={`panel-${id}`}
-      css={styles}
+      className={classnames(className, { [selectedClassName]: selected })}
+      css={styles.container}
       {...mergeProps(rest, focusRingProps)}
     />
   );

--- a/packages/components/src/Tabs/Tab/types.ts
+++ b/packages/components/src/Tabs/Tab/types.ts
@@ -1,6 +1,9 @@
 import { HTMLAttributes } from 'react';
 
-export interface TabProps extends HTMLAttributes<HTMLButtonElement> {
+import { BoxProps } from '../../Box';
+
+export interface TabProps extends BoxProps, HTMLAttributes<HTMLButtonElement> {
   selected?: boolean;
   disabled?: boolean;
+  selectedClassName?: string;
 }

--- a/packages/components/src/Tabs/TabList/index.tsx
+++ b/packages/components/src/Tabs/TabList/index.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { __DEV__, cleanChildren } from '@sajari/react-sdk-utils';
+import { __DEV__, cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement, useRef } from 'react';
 
 import Box from '../../Box';
@@ -9,8 +9,7 @@ import useTabListStyles from './styles';
 import { TabListProps } from './types';
 
 const TabList = React.forwardRef((props: TabListProps, ref?: React.Ref<HTMLDivElement>) => {
-  const { children, onKeyDown, onClick, ...rest } = props;
-  const styles = useTabListStyles();
+  const { children, onKeyDown, onClick, styles: stylesProp, ...rest } = props;
   const {
     id,
     index: selectedIndex,
@@ -19,7 +18,9 @@ const TabList = React.forwardRef((props: TabListProps, ref?: React.Ref<HTMLDivEl
     manual,
     onChangeTab,
     onFocusPanel,
+    disableDefaultStyles = false,
   } = useTabContext();
+  const styles = getStylesObject(useTabListStyles(), disableDefaultStyles);
   const allNodes = useRef<HTMLElement[]>([]);
   const validChildren = cleanChildren(children);
 

--- a/packages/components/src/Tabs/TabList/types.ts
+++ b/packages/components/src/Tabs/TabList/types.ts
@@ -1,6 +1,8 @@
 import React, { HTMLAttributes } from 'react';
 
-export interface TabListProps extends Omit<HTMLAttributes<HTMLDivElement>, 'display'> {
+import { BoxProps } from '../../Box';
+
+export interface TabListProps extends BoxProps, Omit<HTMLAttributes<HTMLDivElement>, 'display'> {
   onKeyDown?: React.KeyboardEventHandler;
   onClick?: React.MouseEventHandler;
 }

--- a/packages/components/src/Tabs/TabPanel/index.tsx
+++ b/packages/components/src/Tabs/TabPanel/index.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
 import { __DEV__, assignRef } from '@sajari/react-sdk-utils';
 import React from 'react';
 
@@ -6,7 +8,7 @@ import { useTabContext } from '../context';
 import { TabPanelProps } from './types';
 
 const TabPanel = React.forwardRef((props: TabPanelProps, ref: React.Ref<HTMLDivElement>) => {
-  const { children, selected, selectedPanelRef, id, ...rest } = props;
+  const { children, selected, selectedPanelRef, id, styles: stylesProp, ...rest } = props;
   const { alwaysRenderChildren } = useTabContext();
 
   return (
@@ -22,6 +24,7 @@ const TabPanel = React.forwardRef((props: TabPanelProps, ref: React.Ref<HTMLDivE
       aria-labelledby={`tab:${id}`}
       hidden={!selected}
       id={`panel:${id}`}
+      css={stylesProp}
       {...rest}
     >
       {(alwaysRenderChildren || selected) && children}

--- a/packages/components/src/Tabs/TabPanel/types.ts
+++ b/packages/components/src/Tabs/TabPanel/types.ts
@@ -1,7 +1,10 @@
 import React, { HTMLAttributes } from 'react';
 
+import { BoxProps } from '../../Box';
+
 export interface TabPanelProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'tabIndex' | 'hidden' | 'id' | 'outline'> {
+  extends BoxProps,
+    Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'tabIndex' | 'hidden' | 'id' | 'outline'> {
   selected?: boolean;
   selectedPanelRef?: React.Ref<HTMLElement>;
   id?: string;

--- a/packages/components/src/Tabs/TabPanels/index.tsx
+++ b/packages/components/src/Tabs/TabPanels/index.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
 import { __DEV__, cleanChildren } from '@sajari/react-sdk-utils';
 import React, { cloneElement } from 'react';
 
@@ -6,7 +8,7 @@ import { useTabContext } from '../context';
 import { TabPanelsProps } from './types';
 
 const TabPanels = React.forwardRef((props: TabPanelsProps, ref?: React.Ref<HTMLDivElement>) => {
-  const { children, ...rest } = props;
+  const { children, styles: stylesProp, ...rest } = props;
   const { index: selectedIndex, selectedPanelRef, id, manual, manualIndex } = useTabContext();
   const validChildren = cleanChildren(children);
 
@@ -19,7 +21,7 @@ const TabPanels = React.forwardRef((props: TabPanelsProps, ref?: React.Ref<HTMLD
   );
 
   return (
-    <Box tabIndex={-1} ref={ref} {...rest}>
+    <Box tabIndex={-1} ref={ref} css={stylesProp} {...rest}>
       {clones}
     </Box>
   );

--- a/packages/components/src/Tabs/TabPanels/types.ts
+++ b/packages/components/src/Tabs/TabPanels/types.ts
@@ -1,3 +1,5 @@
 import { HTMLAttributes } from 'react';
 
-export type TabPanelsProps = Omit<HTMLAttributes<HTMLDivElement>, 'tabIndex'>;
+import { BoxProps } from '../../Box';
+
+export interface TabPanelsProps extends BoxProps, Omit<HTMLAttributes<HTMLDivElement>, 'tabIndex'> {}

--- a/packages/components/src/Tabs/index.tsx
+++ b/packages/components/src/Tabs/index.tsx
@@ -1,3 +1,5 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
 import React, { useRef, useState } from 'react';
 
@@ -15,6 +17,8 @@ const Tabs = React.forwardRef((props: TabsProps, ref?: React.Ref<HTMLDivElement>
     align = 'start',
     fitted,
     alwaysRenderChildren,
+    disableDefaultStyles,
+    styles: stylesProp,
     ...rest
   } = props;
   const { current: isControlled } = useRef(controlledIndex != null);
@@ -88,11 +92,12 @@ const Tabs = React.forwardRef((props: TabsProps, ref?: React.Ref<HTMLDivElement>
     align,
     fitted,
     alwaysRenderChildren,
+    disableDefaultStyles,
   };
 
   return (
     <TabContextProvider value={context}>
-      <Box ref={ref} {...rest}>
+      <Box ref={ref} css={stylesProp} {...rest}>
         {children}
       </Box>
     </TabContextProvider>

--- a/packages/components/src/Tabs/types.ts
+++ b/packages/components/src/Tabs/types.ts
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export interface TabsProps {
+import { BoxProps } from '../Box';
+
+export interface TabsProps extends BoxProps {
   children: React.ReactNode;
   /** Callback when the index (controlled or un-controlled) changes. */
   onChange?: (index: number) => void;
@@ -33,4 +35,5 @@ export interface TabsContextOptions extends Omit<TabsProps, 'children' | 'index'
   selectedPanelRef: React.Ref<HTMLElement>;
   onFocusPanel: () => void;
   alwaysRenderChildren?: boolean;
+  disableDefaultStyles?: boolean;
 }

--- a/packages/components/src/Text/index.tsx
+++ b/packages/components/src/Text/index.tsx
@@ -1,21 +1,19 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { forwardRefWithAs, PropsWithAs } from '@sajari/react-sdk-utils';
+import { forwardRefWithAs, getStylesObject, PropsWithAs } from '@sajari/react-sdk-utils';
 import React from 'react';
 
 import Box from '../Box';
-import { useTextSize } from '../hooks';
 import useTextStyles from './styles';
 import { TextProps } from './types';
 
 type DefaultElement = 'p';
 
 const TextComponent = (props: PropsWithAs<TextProps, DefaultElement>, ref: React.Ref<HTMLParagraphElement>) => {
-  const { as = 'p', size, truncate, ...rest } = props;
-  const styles = useTextStyles({ as, truncate });
-  const sizeStyles = useTextSize({ size });
+  const { as = 'p', truncate, disableDefaultStyles = false, size, styles: stylesProp, ...rest } = props;
+  const styles = getStylesObject(useTextStyles({ as, truncate, size }), disableDefaultStyles);
 
-  return <Box ref={ref} as={as} css={[styles, sizeStyles]} {...rest} />;
+  return <Box ref={ref} as={as} css={[styles.container, stylesProp]} {...rest} />;
 };
 
 const Text = forwardRefWithAs<TextProps, DefaultElement>(TextComponent);

--- a/packages/components/src/Text/styles.ts
+++ b/packages/components/src/Text/styles.ts
@@ -1,29 +1,35 @@
-import { css } from '@emotion/core';
+import { mapStyles } from '@sajari/react-sdk-utils';
 import tw from 'twin.macro';
 
+import { useTextSize } from '../hooks';
 import { mapTruncateValue } from '../utils/styles';
 import { TextElement, TextProps } from './types';
 
 interface UseTextStylesProps {
   as: TextElement;
   truncate: TextProps['truncate'];
+  size: TextProps['size'];
 }
 
-export default function useTextStyles({ as, truncate }: UseTextStylesProps) {
-  const props = [tw`p-0 m-0`, mapTruncateValue(truncate)];
+export default function useTextStyles({ as, truncate, size }: UseTextStylesProps) {
+  const sizeStyles = useTextSize({ size });
+
+  const styles = {
+    container: [tw`p-0 m-0`, mapTruncateValue(truncate), sizeStyles],
+  };
 
   switch (as) {
     case 'small':
-      props.push(tw`text-sm`);
+      styles.container.push(tw`text-sm`);
       break;
 
     case 'pre':
     case 'code':
-      props.push(tw`font-mono font-normal text-code-inline`);
+      styles.container.push(tw`font-mono font-normal text-code-inline`);
       break;
 
     case 'mark':
-      props.push(tw`px-1 text-gray-800 bg-yellow-100`);
+      styles.container.push(tw`px-1 text-gray-800 bg-yellow-100`);
       break;
 
     default:
@@ -31,8 +37,8 @@ export default function useTextStyles({ as, truncate }: UseTextStylesProps) {
   }
 
   if (as === 'code') {
-    props.push(tw`text-red-500`);
+    styles.container.push(tw`text-red-500`);
   }
 
-  return css(props);
+  return mapStyles(styles);
 }

--- a/packages/components/src/Text/types.ts
+++ b/packages/components/src/Text/types.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { BoxProps } from '../Box';
 import { UseTextSizeParams } from '../hooks';
 
 export type TextElement =
@@ -26,7 +27,8 @@ export type TextElement =
   | 'sup'
   | 'strong';
 
-export interface TextProps {
+export interface TextProps extends BoxProps {
+  /** Set the element that the text should render as */
   children?: React.ReactNode;
   /** Whether to truncate the text. Specify a number will use line-clamp */
   truncate?: boolean | 2 | 3 | 4 | 5;

--- a/packages/search-ui/src/ContextProvider/index.tsx
+++ b/packages/search-ui/src/ContextProvider/index.tsx
@@ -19,8 +19,10 @@ const ContextProvider: React.FC<ContextProviderValues> = ({
   searchOnLoad,
   theme,
   ratingMax = 5,
+  disableDefaultStyles = false,
+  customClassNames = {},
 }) => (
-  <Provider value={{ ratingMax }}>
+  <Provider value={{ ratingMax, disableDefaultStyles, customClassNames }}>
     <SearchContextProvider search={search} instant={instant} searchOnLoad={searchOnLoad}>
       <ThemeProvider theme={theme} importantStyles={importantStyles}>
         <I18nextProvider i18n={i18n}>{children}</I18nextProvider>

--- a/packages/search-ui/src/ContextProvider/types.ts
+++ b/packages/search-ui/src/ContextProvider/types.ts
@@ -3,6 +3,19 @@ import { ThemeProviderProps } from '@sajari/react-sdk-utils';
 
 export interface SearchUIContextProviderValues {
   ratingMax?: number;
+  disableDefaultStyles?: boolean;
+  customClassNames?: {
+    pagination?: {
+      container?: string;
+      button?: string;
+      active?: string;
+      disabled?: string;
+      pressed?: string;
+      next?: string;
+      prev?: string;
+      spacerEllipsis?: string;
+    };
+  };
 }
 
 export interface ContextProviderValues

--- a/packages/search-ui/src/ContextProvider/types.ts
+++ b/packages/search-ui/src/ContextProvider/types.ts
@@ -9,8 +9,6 @@ export interface SearchUIContextProviderValues {
       container?: string;
       button?: string;
       active?: string;
-      disabled?: string;
-      pressed?: string;
       next?: string;
       prev?: string;
       spacerEllipsis?: string;

--- a/packages/search-ui/src/PageSize/index.tsx
+++ b/packages/search-ui/src/PageSize/index.tsx
@@ -14,7 +14,7 @@ const defaultSizes = [15, 25, 50, 100];
 
 const PageSize = (props: PageSizeProps) => {
   const { t } = useTranslation();
-  const { label = t('pageSize.label'), sizes = defaultSizes, size } = props;
+  const { label = t('pageSize.label'), sizes = defaultSizes, styles, size, ...rest } = props;
   const { pageSize, setPageSize } = usePageSize();
   const { searched, totalResults } = useSearchContext();
   const id = `page-size-${useId()}`;
@@ -26,7 +26,7 @@ const PageSize = (props: PageSizeProps) => {
   }
 
   return (
-    <div css={tw`flex items-center space-x-4`}>
+    <div css={[tw`flex items-center space-x-4`, styles]} {...rest}>
       <Label htmlFor={id} css={tw`text-gray-500`} size={size}>
         {label}
       </Label>

--- a/packages/search-ui/src/PageSize/types.ts
+++ b/packages/search-ui/src/PageSize/types.ts
@@ -1,4 +1,6 @@
-export interface PageSizeProps {
+import { BoxProps } from '@sajari/react-components';
+
+export interface PageSizeProps extends BoxProps {
   label?: string;
   sizes?: number[];
   size?: 'sm' | 'md' | 'lg';

--- a/packages/search-ui/src/Pagination/index.tsx
+++ b/packages/search-ui/src/Pagination/index.tsx
@@ -4,12 +4,14 @@ import { __DEV__ } from '@sajari/react-sdk-utils';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useSearchUIContext } from '../ContextProvider';
 import { PaginationProps } from './types';
 
 const Pagination = (props: PaginationProps) => {
   const { t } = useTranslation();
-  const { align } = props;
+  const { align, styles } = props;
   const { page, setPage, pageSize, pageCount, totalResults } = usePagination('search');
+  const { customClassNames, disableDefaultStyles } = useSearchUIContext();
 
   return (
     <PurePagination
@@ -26,6 +28,13 @@ const Pagination = (props: PaginationProps) => {
         page: t('pagination.page'),
         current: t('pagination.current'),
       }}
+      styles={styles}
+      className={customClassNames?.pagination?.container}
+      buttonClassName={customClassNames?.pagination?.button}
+      pressedClassName={customClassNames?.pagination?.pressed}
+      prevClassName={customClassNames?.pagination?.prev}
+      nextClassName={customClassNames?.pagination?.next}
+      disableDefaultStyles={disableDefaultStyles}
     />
   );
 };

--- a/packages/search-ui/src/Pagination/index.tsx
+++ b/packages/search-ui/src/Pagination/index.tsx
@@ -31,7 +31,7 @@ const Pagination = (props: PaginationProps) => {
       styles={styles}
       className={customClassNames?.pagination?.container}
       buttonClassName={customClassNames?.pagination?.button}
-      pressedClassName={customClassNames?.pagination?.pressed}
+      activeClassName={customClassNames?.pagination?.active}
       prevClassName={customClassNames?.pagination?.prev}
       nextClassName={customClassNames?.pagination?.next}
       disableDefaultStyles={disableDefaultStyles}

--- a/packages/search-ui/src/Pagination/types.ts
+++ b/packages/search-ui/src/Pagination/types.ts
@@ -1,6 +1,6 @@
-import { PaginationProps as PurePaginationProps } from '@sajari/react-components';
+import { BoxProps, PaginationProps as PurePaginationProps } from '@sajari/react-components';
 
-export interface PaginationProps {
+export interface PaginationProps extends BoxProps {
   /** How to align the pagination */
   align?: PurePaginationProps['align'];
 }

--- a/packages/search-ui/src/Results/components/Message/index.tsx
+++ b/packages/search-ui/src/Results/components/Message/index.tsx
@@ -22,7 +22,6 @@ export default (props: MessageProps) => {
       case 'error':
         return (
           <React.Fragment>
-            {/* @ts-ignore union too complex */}
             <Heading size="3xl" css={tw`text-red-500`}>
               {title}
             </Heading>

--- a/packages/search-ui/src/Results/components/Message/index.tsx
+++ b/packages/search-ui/src/Results/components/Message/index.tsx
@@ -22,6 +22,7 @@ export default (props: MessageProps) => {
       case 'error':
         return (
           <React.Fragment>
+            {/* @ts-ignore union too complex */}
             <Heading size="3xl" css={tw`text-red-500`}>
               {title}
             </Heading>

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -21,6 +21,13 @@ const Result = React.memo(
       token,
       onClick = () => {},
       forceImage,
+      headingClassName,
+      priceClassName,
+      subTitleClassName,
+      ratingClassName,
+      descriptionClassName,
+      disableDefaultStyles,
+      styles: stylesProp,
       ...rest
     } = props;
     const { title, description, subtitle, image, url, price } = values;
@@ -58,7 +65,7 @@ const Result = React.memo(
     }, [appearance]);
 
     return (
-      <article {...rest} css={styles.container}>
+      <article {...rest} css={[styles.container, stylesProp]}>
         {(isValidURL(image, true) || forceImage) && (
           <Link href={clickToken || url} target="_blank" onClick={resultClicked} css={styles.imageContainer}>
             <Image src={image} css={styles.image} aspectRatio={imageAspectRatio} objectFit={imageObjectFit} />
@@ -67,21 +74,21 @@ const Result = React.memo(
 
         <div css={tw`flex-1 min-w-0`}>
           <div css={tw`flex items-start`}>
-            <Heading as="h1" size="base" css={[tw`flex-1 font-medium`]}>
+            <Heading as="h1" size="base" css={[tw`flex-1 font-medium`]} className={headingClassName}>
               <Link href={clickToken || url} target="_blank" onClick={resultClicked}>
                 {decodeHTML(title)}
               </Link>
             </Heading>
 
             {price && appearance === 'list' && (
-              <div css={tw`ml-6`}>
+              <div css={tw`ml-6`} className={priceClassName}>
                 <Text>{formatPrice(price, currencyCode)}</Text>
               </div>
             )}
           </div>
 
           {(subtitle || isNumber(rating)) && appearance === 'list' && (
-            <div css={tw`flex items-baseline mt-1`}>
+            <div css={tw`flex items-baseline mt-1`} className={subTitleClassName}>
               {subtitle &&
                 (isValidURL(subtitle) ? (
                   <Link
@@ -95,12 +102,12 @@ const Result = React.memo(
                 ) : (
                   <Text css={tw`mr-3 text-xs text-gray-400`}>{subtitle}</Text>
                 ))}
-              {isNumber(rating) && <Rating value={rating} max={ratingMax} />}
+              {isNumber(rating) && <Rating value={rating} max={ratingMax} className={ratingClassName} />}
             </div>
           )}
 
           {description && appearance === 'list' && (
-            <Text truncate={2} css={tw`mt-1 text-sm text-gray-500`}>
+            <Text truncate={2} css={tw`mt-1 text-sm text-gray-500`} className={descriptionClassName}>
               {decodeHTML(description)}
             </Text>
           )}
@@ -108,7 +115,11 @@ const Result = React.memo(
           {(price || isNumber(rating)) && appearance === 'grid' && (
             <div css={tw`mt-1 space-y-1 text-center`}>
               {isNumber(rating) && <Rating value={rating} max={ratingMax} />}
-              {price && <Text css={tw`text-gray-500`}>{formatPrice(price, currencyCode)}</Text>}
+              {price && (
+                <Text css={tw`text-gray-500`} className={priceClassName}>
+                  {formatPrice(price, currencyCode)}
+                </Text>
+              )}
             </div>
           )}
         </div>

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -114,7 +114,7 @@ const Result = React.memo(
 
           {(price || isNumber(rating)) && appearance === 'grid' && (
             <div css={tw`mt-1 space-y-1 text-center`}>
-              {isNumber(rating) && <Rating value={rating} max={ratingMax} />}
+              {isNumber(rating) && <Rating value={rating} max={ratingMax} className={ratingClassName} />}
               {price && (
                 <Text css={tw`text-gray-500`} className={priceClassName}>
                   {formatPrice(price, currencyCode)}

--- a/packages/search-ui/src/Results/components/Result/types.ts
+++ b/packages/search-ui/src/Results/components/Result/types.ts
@@ -1,7 +1,7 @@
 import { Token } from '@sajari/react-hooks';
 import React from 'react';
 
-import { ResultsProps, ResultValues } from '../../types';
+import { ResultCustomClassNames, ResultsProps, ResultValues } from '../../types';
 
 interface Props extends Omit<ResultsProps, 'columns'> {
   values: Omit<ResultValues, '_id'>;
@@ -15,4 +15,4 @@ interface Props extends Omit<ResultsProps, 'columns'> {
 
 type HTMLAttributes = Omit<React.HTMLAttributes<HTMLDivElement>, keyof Props>;
 
-export interface ResultProps extends Props, HTMLAttributes {}
+export interface ResultProps extends Props, HTMLAttributes, ResultCustomClassNames {}

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -19,7 +19,14 @@ const Results = (props: ResultsProps) => {
     rawResults,
   ]);
   const { query } = useQuery();
-  const { defaultAppearance, appearance = viewType, className, ...rest } = props;
+  const {
+    defaultAppearance,
+    appearance = viewType,
+    className,
+    disableDefaultStyles = false,
+    styles: stylesProp,
+    ...rest
+  } = props;
   const [width, setWidth] = React.useState(0);
   const { handleResultClicked } = useTracking();
   const { ratingMax } = useSearchUIContext();
@@ -66,7 +73,11 @@ const Results = (props: ResultsProps) => {
   }
 
   return (
-    <ResizeObserver onResize={(rect) => setWidth(rect.width)} css={[styles.container]} className={className}>
+    <ResizeObserver
+      onResize={(rect) => setWidth(rect.width)}
+      css={[styles.container, stylesProp]}
+      className={className}
+    >
       {results?.map(({ values, token }, i) => (
         <Result
           onClick={handleResultClicked}
@@ -77,6 +88,7 @@ const Results = (props: ResultsProps) => {
           values={values}
           appearance={appearance}
           forceImage={hasImages}
+          disableDefaultStyles={disableDefaultStyles}
           {...rest}
         />
       ))}

--- a/packages/search-ui/src/Results/styles.ts
+++ b/packages/search-ui/src/Results/styles.ts
@@ -23,7 +23,7 @@ export default function useResultsStyles({
   gap: gapProp = appearance === 'list' ? { 0: 4, 640: 8 } : undefined,
   width,
 }: Props) {
-  const styles: Record<string, TwStyle[]> = {
+  const styles: Record<'container', TwStyle[]> = {
     container: [],
   };
 

--- a/packages/search-ui/src/Results/types.ts
+++ b/packages/search-ui/src/Results/types.ts
@@ -1,10 +1,18 @@
 import { BoxProps, ImageProps } from '@sajari/react-components';
 
+export interface ResultCustomClassNames {
+  headingClassName?: string;
+  priceClassName?: string;
+  subTitleClassName?: string;
+  ratingClassName?: string;
+  descriptionClassName?: string;
+}
+
 export type ColumnValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export type GapValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 type ApperanceValue = 'list' | 'grid';
 
-export interface ResultsProps extends BoxProps {
+export interface ResultsProps extends BoxProps, ResultCustomClassNames {
   appearance?: ApperanceValue;
   defaultAppearance?: ApperanceValue;
   ratingMax?: number;
@@ -14,6 +22,7 @@ export interface ResultsProps extends BoxProps {
   columnMinWidth?: number;
   columns?: ColumnValue | Record<number, ColumnValue>;
   gap?: GapValue | Record<number, GapValue>;
+  noResultsClassName?: string;
 }
 
 export interface ResultValues {

--- a/packages/search-ui/src/Sorting/index.tsx
+++ b/packages/search-ui/src/Sorting/index.tsx
@@ -4,26 +4,39 @@ import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
 import { Label, Select } from '@sajari/react-components';
 import { useSorting } from '@sajari/react-hooks';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import { useTranslation } from 'react-i18next';
 import tw from 'twin.macro';
 
+import { useSearchUIContext } from '../ContextProvider';
 import { SortingProps, SortOption } from './types';
 
 const defaultOptions: SortOption[] = [{ name: 'Most relevant', value: '' }];
 
 const Sorting = (props: SortingProps) => {
   const { t } = useTranslation();
-  const { label = t('sorting.label'), options = defaultOptions, size } = props;
+  const { label = t('sorting.label'), options = defaultOptions, size, styles: stylesProp, ...rest } = props;
+  const { disableDefaultStyles = false } = useSearchUIContext();
   const { sorting, setSorting } = useSorting();
   const id = `sorting-${useId()}`;
 
+  const styles = getStylesObject(
+    { container: [tw`flex items-center space-x-4`], label: [tw`text-sm text-gray-500`] },
+    disableDefaultStyles,
+  );
+
   return (
-    <div css={tw`flex items-center space-x-4`}>
-      <Label htmlFor={id} css={tw`text-gray-500`} size={size}>
+    <div css={[styles.container, stylesProp]} {...rest}>
+      <Label htmlFor={id} css={styles.label} size={size} disableDefaultStyles={disableDefaultStyles}>
         {label}
       </Label>
-      <Select id={id} value={sorting} onChange={(e) => setSorting(e.target.value)} size={size}>
+      <Select
+        id={id}
+        value={sorting}
+        onChange={(e) => setSorting(e.target.value)}
+        size={size}
+        disableDefaultStyles={disableDefaultStyles}
+      >
         {options.map((s, i) => (
           <option key={`${id}-option-${i}`} value={s.value}>
             {s.name}

--- a/packages/search-ui/src/Sorting/types.ts
+++ b/packages/search-ui/src/Sorting/types.ts
@@ -1,9 +1,11 @@
+import { BoxProps } from '@sajari/react-components';
+
 export type SortOption = {
   name: string;
   value: string;
 };
 
-export interface SortingProps {
+export interface SortingProps extends BoxProps {
   label?: string;
   options?: SortOption[];
   size?: 'sm' | 'md' | 'lg';

--- a/packages/search-ui/src/Summary/index.tsx
+++ b/packages/search-ui/src/Summary/index.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 import { LiveMessage } from 'react-aria-live';
 import { useTranslation } from 'react-i18next';
 
+import { useSearchUIContext } from '../ContextProvider';
 import { SummaryProps } from './types';
 
 const Summary = (props: SummaryProps) => {
   const { latency, totalResults, search, queryValues, searched } = useSearchContext();
+  const { disableDefaultStyles } = useSearchUIContext();
   const { showOverride = true, showLatency = false, ...rest } = props;
   const query = queryValues?.get('q') ?? '';
   const { completion } = useAutocomplete();
@@ -30,7 +32,7 @@ const Summary = (props: SummaryProps) => {
         aria-live="polite"
       />
 
-      <Text {...rest}>
+      <Text {...rest} disableDefaultStyles={disableDefaultStyles}>
         <Box
           as="span"
           dangerouslySetInnerHTML={{
@@ -45,7 +47,12 @@ const Summary = (props: SummaryProps) => {
         {completion && completion !== query.trim() && showOverride ? (
           <React.Fragment>
             {`. ${t('summary.alternative')} `}
-            <Button onClick={() => search(completion)} spacing="none" appearance="link">
+            <Button
+              onClick={() => search(completion)}
+              spacing="none"
+              appearance="link"
+              disableDefaultStyles={disableDefaultStyles}
+            >
               {completion}
             </Button>
             .

--- a/packages/search-ui/src/Summary/types.ts
+++ b/packages/search-ui/src/Summary/types.ts
@@ -1,6 +1,6 @@
-import { TextProps } from '@sajari/react-components';
+import { BoxProps, TextProps } from '@sajari/react-components';
 
-export interface SummaryProps extends Omit<TextProps, 'children'> {
+export interface SummaryProps extends BoxProps, Omit<TextProps, 'children'> {
   /** Show the query override text */
   showOverride?: boolean;
   /** Show the search latency  */

--- a/packages/search-ui/src/ViewType/index.tsx
+++ b/packages/search-ui/src/ViewType/index.tsx
@@ -18,7 +18,6 @@ const ViewType = (props: ViewTypeProps) => {
 
   return (
     <div css={[tw`flex items-center space-x-4`, stylesProp]} aria-labelledby={id} {...rest}>
-      {/* @ts-ignore Union too complex? */}
       <Text id={id} css={tw`text-gray-500`} size={size}>
         {label}
       </Text>

--- a/packages/search-ui/src/ViewType/index.tsx
+++ b/packages/search-ui/src/ViewType/index.tsx
@@ -12,17 +12,17 @@ import { ViewTypeProps } from './types';
 
 const ViewType = (props: ViewTypeProps) => {
   const { t } = useTranslation();
-  const { label = t('viewType.label'), size } = props;
+  const { label = t('viewType.label'), size, styles: stylesProp, ...rest } = props;
   const id = `view-type-${useId()}`;
   const { viewType, setViewType } = useSearchContext();
 
   return (
-    <div css={tw`flex items-center space-x-4`} aria-labelledby={id}>
+    <div css={[tw`flex items-center space-x-4`, stylesProp]} aria-labelledby={id} {...rest}>
       {/* @ts-ignore Union too complex? */}
       <Text id={id} css={tw`text-gray-500`} size={size}>
         {label}
       </Text>
-      <ButtonGroup attached>
+      <ButtonGroup id={id} attached>
         <Button
           onClick={() => setViewType('grid')}
           size={size}

--- a/packages/search-ui/src/ViewType/types.ts
+++ b/packages/search-ui/src/ViewType/types.ts
@@ -1,4 +1,6 @@
-export interface ViewTypeProps {
+import { BoxProps } from '@sajari/react-components';
+
+export interface ViewTypeProps extends BoxProps {
   label?: string;
   size?: 'sm' | 'md' | 'lg';
 }

--- a/packages/utils/src/styles/index.ts
+++ b/packages/utils/src/styles/index.ts
@@ -1,12 +1,21 @@
 import { css, SerializedStyles } from '@emotion/core';
 import { TwStyle } from 'twin.macro';
 
-export function mapStyles(styles: Record<string, (TwStyle | string)[]>): Record<string, SerializedStyles> {
+export function mapStyles<T = Record<string, (TwStyle | string)[]>>(styles: T): Record<keyof T, SerializedStyles> {
   return Object.entries(styles).reduce((obj, [key, value]) => Object.assign(obj, { [key]: css(value) }), {}) as Record<
     keyof typeof styles,
     SerializedStyles
   >;
 }
+
+export function getStylesObject<T = Record<string, SerializedStyles>>(styles: T, disableDefaultStyles: boolean) {
+  if (disableDefaultStyles) {
+    return {} as Partial<T>;
+  }
+
+  return styles;
+}
+
 export { default as styled } from './styled';
 export { default as tailwindConfig } from './tailwind.config';
 export { default as ThemeProvider } from './theming';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,6 +3852,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/classnames@^2.2.11":
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
+  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
+
 "@types/color-convert@*":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-1.9.0.tgz#bfa8203e41e7c65471e9841d7e306a7cd8b5172d"
@@ -3870,10 +3875,6 @@
   integrity sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==
   dependencies:
     "@types/color-convert" "*"
-"@types/classnames@^2.2.11":
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
-  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3870,6 +3870,10 @@
   integrity sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==
   dependencies:
     "@types/color-convert" "*"
+"@types/classnames@^2.2.11":
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
+  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
- [x] support `className` and `styles` prop for components.
- [x] option in Context to disable default styling.
- [x] add config in Context to pass down classNames to components (as below example).


```tsx
function Example() {
  const pipeline = new Pipeline(
    {
      project: '1594153711901724220',
      collection: 'bestbuy',
      endpoint: 'https://jsonapi-us-valkyrie.sajari.net',
    },
    'query',
  );

  const variables = new Variables({ resultsPerPage: 3 });

  const SearchPlayground = React.memo(() => {
    useSearch('iphone');

    return (
      <>
        <Results appearance="grid" />
        <div style={{ display: 'flex', justifyContent: 'center', marginTop: '30px' }}>
          <Pagination />
        </div>
      </>
    );
  });

  return (
    <ContextProvider
      search={{ pipeline, variables, fields: { title: 'name', subtitle: 'brand' } }}
      customClassNames={{
        pagination: {
          container: 'sj-pagination',
          button: 'sj-pagination-btn',
          next: 'sj-pagination-next',
          prev: 'sj-pagination-prev',
        },
      }}
      disableDefaultStyles
    >
      <SearchPlayground />
    </ContextProvider>
  );
}
```

Note that there are a couple of components like `Combobox` or `Results` has been updated yet. Since the PR is already bulky so I'll create a separate PR for those components for getting a better review once the change was merged.