### PR TITLE
V3: fix enter key not trigger search using Input component

### DIFF
--- a/docs/pages/search-ui/input.mdx
+++ b/docs/pages/search-ui/input.mdx
@@ -24,15 +24,6 @@ import { Input } from 'sajari/react-search-ui';
 </>
 ```
 
-## Standard
-
-```jsx
-<>
-  <Input label="Search something" mode="standard" />
-  <Results className="mt-4" />
-</>
-```
-
 ## Suggestions
 
 ```jsx

--- a/docs/pages/search-ui/input.mdx
+++ b/docs/pages/search-ui/input.mdx
@@ -24,6 +24,15 @@ import { Input } from 'sajari/react-search-ui';
 </>
 ```
 
+## Standard
+
+```jsx
+<>
+  <Input label="Search something" mode="standard" />
+  <Results className="mt-4" />
+</>
+```
+
 ## Suggestions
 
 ```jsx

--- a/packages/components/src/Combobox/components/DropdownItem/index.tsx
+++ b/packages/components/src/Combobox/components/DropdownItem/index.tsx
@@ -11,7 +11,7 @@ import { DropdownItemProps } from './types';
 
 const DropdownItem = (props: DropdownItemProps) => {
   const { value, index, selected } = props;
-  const { typedInputValue, getItemProps, showDropdownTips, itemToString } = useComboboxContext();
+  const { typedInputValue, getItemProps, showDropdownTips, itemToString, onSelect } = useComboboxContext();
   const stringItem = itemToString(value);
   const styles = useDropdownItemStyles(props);
 
@@ -38,6 +38,11 @@ const DropdownItem = (props: DropdownItemProps) => {
       {...getItemProps({
         index,
         item: value,
+        onClick: () => {
+          if (onSelect) {
+            onSelect(value);
+          }
+        },
       })}
       key={`${stringItem}_${index}`}
       css={styles.item}

--- a/packages/components/src/Combobox/context.tsx
+++ b/packages/components/src/Combobox/context.tsx
@@ -19,6 +19,7 @@ interface ComboboxContextProps<T = any> {
   renderItem?: ComboboxProps<T>['renderItem'];
   itemToString: Required<ComboboxProps<T>>['itemToString'];
   itemToUrl: Required<ComboboxProps<T>>['itemToUrl'];
+  onSelect: ComboboxProps<T>['onSelect'];
 }
 
 const [ComboboxContextProvider, useComboboxContext] = createContext<ComboboxContextProps>({

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -61,6 +61,7 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     highlightedIndex,
     inputValue,
     setInputValue,
+    closeMenu,
   } = useCombobox<T>({
     items,
     itemToString,
@@ -153,6 +154,12 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
             }
             return changes;
 
+          case useCombobox.stateChangeTypes.InputKeyDownEnter:
+            return {
+              ...changes,
+              isOpen: false,
+            };
+
           default:
             return changes;
         }
@@ -204,6 +211,7 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     showPoweredBy,
     typedInputValue,
     renderItem,
+    onSelect,
     itemToString,
     itemToUrl,
   };
@@ -253,6 +261,10 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
                   // Only if the user isn't focused on an item in the suggestions
                   if (e.key === 'Enter' && highlightedIndex === -1) {
                     (e.nativeEvent as any).preventDownshiftDefault = true;
+
+                    if (mode === 'suggestions') {
+                      closeMenu();
+                    }
                   }
 
                   if (mode !== 'results' && e.key === 'Enter' && highlightedIndex > -1) {

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -59,12 +59,12 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.Ref<HTMLInput
           if (searchInstant) {
             searchInstant(value);
           }
-        } else if (mode === 'instant') {
+        } else if (mode === 'instant' || mode === 'results') {
           search(value);
         }
       }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && mode === 'typeahead') {
+        if (e.key === 'Enter' && (mode === 'typeahead' || mode === 'suggestions' || mode === 'standard')) {
           search((e.target as HTMLInputElement).value);
         }
       }}


### PR DESCRIPTION
Resolve some issues related to Input component:

- [x] enter key not trigger search in `suggestions` and `standard` mode
- [x] dropdown not open in `results` mode
- [x] mouse clicking on dropdown item in `suggestions` mode doesn't not trigger search 