### PR TITLE
V3:  fix wrong use of Input component in Filter

### DIFF
--- a/packages/search-ui/src/Filter/ListFilter.tsx
+++ b/packages/search-ui/src/Filter/ListFilter.tsx
@@ -1,12 +1,11 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { Button, Checkbox, CheckboxGroup, Radio, RadioGroup } from '@sajari/react-components';
+import { Button, Checkbox, CheckboxGroup, Combobox, Radio, RadioGroup } from '@sajari/react-components';
 import { useFilter, useQuery } from '@sajari/react-hooks';
 import { useCallback, useEffect, useState } from 'react';
 import tw from 'twin.macro';
 
 import { IconSmallChevronDown, IconSmallChevronUp } from '../assets/icons';
-import Input from '../Input';
 import Box from './Box';
 import { ListFilterProps } from './types';
 import { pinItems, sortItems } from './utils';
@@ -22,6 +21,7 @@ const ListFilter = ({
   sort = 'count',
   sortAscending = sort !== 'count',
   itemRender,
+  placeholder = 'Search',
 }: Omit<ListFilterProps, 'type'>) => {
   const [query, setQuery] = useState('');
   const { query: q } = useQuery();
@@ -59,9 +59,10 @@ const ListFilter = ({
     <Box title={title} showReset={selected.length > 0 && multi} onReset={reset}>
       {searchable ? (
         <div css={tw`mb-2`}>
-          <Input
+          <Combobox
             value={query}
             size="sm"
+            placeholder={placeholder}
             onChange={(value) => {
               setQuery(value || '');
             }}

--- a/packages/search-ui/src/Filter/types.ts
+++ b/packages/search-ui/src/Filter/types.ts
@@ -22,6 +22,8 @@ export interface ListFilterProps extends BaseFilterProps {
   limit?: number;
   /** If true, display an input for searching through filter items */
   searchable?: boolean;
+  /** The placeholder for search input */
+  placeholder?: string;
   /** If true, sort selected items on top */
   pinSelected?: boolean;
   /** How to sort the items in the list */


### PR DESCRIPTION
Use `Combobox` instead of `Input` in `Filter` component to fix the issue when a search is unexpectedly triggered if we type in the search box in a filter list.

![image](https://user-images.githubusercontent.com/12707960/100380127-c53fbf80-3048-11eb-9731-6004527fc2aa.png)
