### PR TITLE
V3: improve key mapping for mapStyles util

### DIFF
--- a/packages/components/src/Combobox/components/DropdownItem/styles.ts
+++ b/packages/components/src/Combobox/components/DropdownItem/styles.ts
@@ -6,7 +6,7 @@ import { DropdownItemProps } from './types';
 export function useDropdownItemStyles(props: DropdownItemProps) {
   const theme = useTheme();
   const { selected } = props;
-  const styles: Record<string, (TwStyle | string)[]> = {
+  const styles: Record<'item' | 'highlight' | 'label', (TwStyle | string)[]> = {
     item: [
       tw`flex items-center w-full px-2 py-1 leading-5 text-left transition-all duration-75 rounded cursor-pointer`,
     ],

--- a/packages/components/src/Combobox/components/DropdownItem/styles.ts
+++ b/packages/components/src/Combobox/components/DropdownItem/styles.ts
@@ -1,18 +1,18 @@
-import { mapStyles, useTheme } from '@sajari/react-sdk-utils';
-import tw, { TwStyle } from 'twin.macro';
+import { inferStylesObjectKeys, mapStyles, useTheme } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
 
 import { DropdownItemProps } from './types';
 
 export function useDropdownItemStyles(props: DropdownItemProps) {
   const theme = useTheme();
   const { selected } = props;
-  const styles: Record<'item' | 'highlight' | 'label', (TwStyle | string)[]> = {
+  const styles = inferStylesObjectKeys({
     item: [
       tw`flex items-center w-full px-2 py-1 leading-5 text-left transition-all duration-75 rounded cursor-pointer`,
     ],
     highlight: [tw`font-semibold`],
     label: [tw`flex items-center ml-auto text-xs text-gray-400 transition-opacity duration-75`],
-  };
+  });
 
   if (selected) {
     styles.item.push(`color: ${theme.color.primary.text}; background: ${theme.color.primary.active};`);

--- a/packages/components/src/Combobox/components/DropdownResult/index.tsx
+++ b/packages/components/src/Combobox/components/DropdownResult/index.tsx
@@ -24,7 +24,7 @@ const DropdownResult = (props: DropdownResultProps) => {
     >
       <a href={value.url} css={styles.item}>
         <div css={styles.imageContainer}>
-          <Image src={value.image} css={styles.image} aspectRatio={1} objectFit="contain" />
+          <Image src={value.image} aspectRatio={1} objectFit="contain" />
         </div>
 
         <div css={styles.textContainer}>

--- a/packages/components/src/Combobox/components/DropdownResult/styles.ts
+++ b/packages/components/src/Combobox/components/DropdownResult/styles.ts
@@ -5,7 +5,7 @@ import { DropdownResultProps } from './types';
 
 export function useDropdownItemStyles(props: DropdownResultProps) {
   const { selected } = props;
-  const styles: Record<string, (TwStyle | string)[]> = {
+  const styles: Record<'item' | 'imageContainer' | 'textContainer', (TwStyle | string)[]> = {
     item: [
       tw`flex items-center w-full px-2 py-1 text-sm leading-5 text-left transition-all duration-75 rounded cursor-pointer`,
     ],

--- a/packages/components/src/Combobox/components/DropdownResult/styles.ts
+++ b/packages/components/src/Combobox/components/DropdownResult/styles.ts
@@ -1,17 +1,17 @@
-import { mapStyles } from '@sajari/react-sdk-utils';
-import tw, { TwStyle } from 'twin.macro';
+import { inferStylesObjectKeys, mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
 
 import { DropdownResultProps } from './types';
 
 export function useDropdownItemStyles(props: DropdownResultProps) {
   const { selected } = props;
-  const styles: Record<'item' | 'imageContainer' | 'textContainer', (TwStyle | string)[]> = {
+  const styles = inferStylesObjectKeys({
     item: [
       tw`flex items-center w-full px-2 py-1 text-sm leading-5 text-left transition-all duration-75 rounded cursor-pointer`,
     ],
     imageContainer: [tw`flex-none w-12 h-12 mr-6`],
     textContainer: [tw`min-w-0 space-y-0.5`],
-  };
+  });
 
   if (selected) {
     styles.item.push(tw`bg-gray-100`);

--- a/packages/components/src/Label/styles.ts
+++ b/packages/components/src/Label/styles.ts
@@ -1,13 +1,13 @@
-import { mapStyles } from '@sajari/react-sdk-utils';
-import tw, { TwStyle } from 'twin.macro';
+import { inferStylesObjectKeys, mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
 
 import { useTextSize } from '../hooks';
 import { LabelProps } from './types';
 
 export default function useLabelStyles({ visuallyHidden, size }: LabelProps) {
-  const styles: Record<'container', TwStyle[]> = {
+  const styles = inferStylesObjectKeys({
     container: [],
-  };
+  });
 
   if (visuallyHidden) {
     styles.container.push(tw`sr-only`);

--- a/packages/components/src/Tabs/TabList/styles.ts
+++ b/packages/components/src/Tabs/TabList/styles.ts
@@ -1,11 +1,11 @@
 import { mapStyles } from '@sajari/react-sdk-utils';
-import tw, { theme as twTheme, TwStyle } from 'twin.macro';
+import tw, { theme as twTheme } from 'twin.macro';
 
 import { useTabContext } from '../context';
 
 export default function useTabListStyles() {
   const { align } = useTabContext();
-  const styles: Record<string, TwStyle[]> = {
+  const styles = {
     container: [
       tw`overflow-auto whitespace-no-wrap`,
       { boxShadow: `inset 0 -1px 0 ${twTheme`colors.gray.200`.toString()}` },

--- a/packages/search-ui/src/Results/components/Result/styles.ts
+++ b/packages/search-ui/src/Results/components/Result/styles.ts
@@ -6,7 +6,7 @@ import { ResultProps } from './types';
 export default function useResultStyles(props: ResultProps) {
   const { appearance } = props;
 
-  const styles: Record<string, TwStyle[]> = {
+  const styles: Record<'container' | 'imageContainer' | 'image', TwStyle[]> = {
     container: [],
     imageContainer: [],
     image: [tw`rounded-md`],

--- a/packages/utils/src/styles/index.ts
+++ b/packages/utils/src/styles/index.ts
@@ -16,6 +16,10 @@ export function getStylesObject<T = Record<string, SerializedStyles>>(styles: T,
   return styles;
 }
 
+export function inferStylesObjectKeys<T, K = (TwStyle | string)[]>(obj: T) {
+  return (obj as unknown) as Record<keyof T, K>;
+}
+
 export { default as styled } from './styled';
 export { default as tailwindConfig } from './tailwind.config';
 export { default as ThemeProvider } from './theming';


### PR DESCRIPTION
Use the power of generic to retain the keys of `styles` object for the output of `mapStyles` function for better code autocompletion and let TS keep an eye on `undefined` check.

Before:

![image](https://user-images.githubusercontent.com/12707960/100626270-338dc600-3358-11eb-9f46-4a7ac86f1927.png)

After:

![image](https://user-images.githubusercontent.com/12707960/100626220-1eb13280-3358-11eb-8951-5a6b296c42de.png)
