### PR TITLE
V3: simplify hooks logic

### DIFF
--- a/docs/pages/hooks/usepagesize.mdx
+++ b/docs/pages/hooks/usepagesize.mdx
@@ -30,6 +30,10 @@ function Example() {
     const { pageSize, setPageSize } = usePageSize();
     const { query } = useQuery();
 
+    React.useEffect(() => {
+      search();
+    }, [pageSize]);
+
     return (
       <div className="flex flex-col space-y-6">
         <div className="flex space-x-4">

--- a/docs/pages/hooks/usequery.mdx
+++ b/docs/pages/hooks/usequery.mdx
@@ -31,7 +31,11 @@ function Example() {
 // TODO: use Results component once done mapping with the response from backend
 function Example() {
   const { query, setQuery } = useQuery();
-  const { results = [] } = useSearch();
+  const { results = [], search } = useSearch();
+
+  React.useEffect(() => {
+    search();
+  }, [query]);
 
   return (
     <>

--- a/docs/pages/hooks/usesorting.mdx
+++ b/docs/pages/hooks/usesorting.mdx
@@ -35,6 +35,11 @@ function Example() {
 
   const SearchPlayground = React.memo(() => {
     const { sorting, setSorting } = useSorting();
+    const { search } = useSearch();
+
+    React.useEffect(() => {
+      search();
+    }, [sorting]);
 
     return (
       <div className="flex flex-col space-y-6">

--- a/packages/hooks/src/usePageSize/index.ts
+++ b/packages/hooks/src/usePageSize/index.ts
@@ -7,7 +7,6 @@ import { UsePageSizeResult } from './types';
 function usePageSize(): UsePageSizeResult {
   const {
     search: {
-      search,
       config: { resultsPerPageParam },
       variables,
     },
@@ -16,9 +15,8 @@ function usePageSize(): UsePageSizeResult {
   const setPageSize = React.useCallback(
     (size: number) => {
       variables.set({ [resultsPerPageParam]: size });
-      search();
     },
-    [variables, search],
+    [variables],
   );
 
   const pageSize = parseInt(variables.get()[resultsPerPageParam], 10);

--- a/packages/hooks/src/useQuery/index.ts
+++ b/packages/hooks/src/useQuery/index.ts
@@ -4,15 +4,14 @@ import { useContext } from '../SearchContextProvider';
 
 function useQuery() {
   const {
-    search: { search, variables, query },
+    search: { variables, query },
   } = useContext();
 
   const setQuery = useCallback(
     (q: string) => {
       variables.set({ q });
-      search(q);
     },
-    [search, variables],
+    [variables],
   );
 
   return { query, setQuery };

--- a/packages/hooks/src/useSorting/index.ts
+++ b/packages/hooks/src/useSorting/index.ts
@@ -5,15 +5,14 @@ import { UseSortingResult } from './types';
 
 function useSorting(): UseSortingResult {
   const {
-    search: { search, variables },
+    search: { variables },
   } = useContext();
 
   const setSorting = useCallback(
     (order: string) => {
       variables.set({ sort: order });
-      search();
     },
-    [variables, search],
+    [variables],
   );
 
   return {

--- a/packages/search-ui/src/PageSize/index.tsx
+++ b/packages/search-ui/src/PageSize/index.tsx
@@ -5,6 +5,7 @@ import { useId } from '@reach/auto-id';
 import { Label, Select } from '@sajari/react-components';
 import { usePageSize, useSearchContext } from '@sajari/react-hooks';
 import { __DEV__ } from '@sajari/react-sdk-utils';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import tw from 'twin.macro';
 
@@ -16,7 +17,7 @@ const PageSize = (props: PageSizeProps) => {
   const { t } = useTranslation();
   const { label = t('pageSize.label'), sizes = defaultSizes, size } = props;
   const { pageSize, setPageSize } = usePageSize();
-  const { searched, totalResults } = useSearchContext();
+  const { searched, totalResults, search } = useSearchContext();
   const id = `page-size-${useId()}`;
   const sizesSorted = sizes.sort((a, b) => a - b);
   const [min] = sizesSorted;
@@ -24,6 +25,10 @@ const PageSize = (props: PageSizeProps) => {
   if ((searched && totalResults === 0) || min > totalResults) {
     return null;
   }
+
+  React.useEffect(() => {
+    search();
+  }, [pageSize]);
 
   return (
     <div css={tw`flex items-center space-x-4`}>

--- a/packages/search-ui/src/Sorting/index.tsx
+++ b/packages/search-ui/src/Sorting/index.tsx
@@ -3,8 +3,9 @@
 import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
 import { Label, Select } from '@sajari/react-components';
-import { useSorting } from '@sajari/react-hooks';
+import { useSearchContext, useSorting } from '@sajari/react-hooks';
 import { __DEV__ } from '@sajari/react-sdk-utils';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import tw from 'twin.macro';
 
@@ -16,7 +17,12 @@ const Sorting = (props: SortingProps) => {
   const { t } = useTranslation();
   const { label = t('sorting.label'), options = defaultOptions, size } = props;
   const { sorting, setSorting } = useSorting();
+  const { search } = useSearchContext();
   const id = `sorting-${useId()}`;
+
+  React.useEffect(() => {
+    search();
+  }, [sorting]);
 
   return (
     <div css={tw`flex items-center space-x-4`}>


### PR DESCRIPTION
## Why
At first it seemed convenient that we search whenever the parameters changed but on second thought, hooks should be minimal and straighforward without side effect - those effects should go in the `search-ui` package instead
## What this PR does
- [x] Remove call to `search` on hooks
- [x] Add `useEffect` inside some compositions