### PR TITLE
V3: add option to control styles for page size

### DIFF
--- a/packages/search-ui/src/ContextProvider/types.ts
+++ b/packages/search-ui/src/ContextProvider/types.ts
@@ -18,6 +18,11 @@ export interface SearchUIContextProviderValues {
       label?: string;
       buttonGroup?: string;
     };
+    pageSize?: {
+      container?: string;
+      label?: string;
+      select?: string;
+    };
   };
 }
 

--- a/packages/search-ui/src/PageSize/index.tsx
+++ b/packages/search-ui/src/PageSize/index.tsx
@@ -4,17 +4,19 @@ import { jsx } from '@emotion/core';
 import { useId } from '@reach/auto-id';
 import { Label, Select } from '@sajari/react-components';
 import { usePageSize, useSearchContext } from '@sajari/react-hooks';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import { useTranslation } from 'react-i18next';
-import tw from 'twin.macro';
 
+import { useSearchUIContext } from '../ContextProvider';
+import usePageSizeStyles from './styles';
 import { PageSizeProps } from './types';
 
 const defaultSizes = [15, 25, 50, 100];
 
 const PageSize = (props: PageSizeProps) => {
   const { t } = useTranslation();
-  const { label = t('pageSize.label'), sizes = defaultSizes, styles, size, ...rest } = props;
+  const { customClassNames, disableDefaultStyles = false } = useSearchUIContext();
+  const { label = t('pageSize.label'), sizes = defaultSizes, styles: stylesProp, size, ...rest } = props;
   const { pageSize, setPageSize } = usePageSize();
   const { searched, totalResults } = useSearchContext();
   const id = `page-size-${useId()}`;
@@ -25,12 +27,27 @@ const PageSize = (props: PageSizeProps) => {
     return null;
   }
 
+  const styles = getStylesObject(usePageSizeStyles(), disableDefaultStyles);
+
   return (
-    <div css={[tw`flex items-center space-x-4`, styles]} {...rest}>
-      <Label htmlFor={id} css={tw`text-gray-500`} size={size}>
+    <div css={[styles.container, stylesProp]} {...rest} className={customClassNames.pageSize?.container}>
+      <Label
+        htmlFor={id}
+        css={styles.label}
+        size={size}
+        disableDefaultStyles={disableDefaultStyles}
+        className={customClassNames.pageSize?.label}
+      >
         {label}
       </Label>
-      <Select id={id} value={`${pageSize}`} onChange={(e) => setPageSize(parseInt(e.target.value, 10))} size={size}>
+      <Select
+        id={id}
+        value={`${pageSize}`}
+        onChange={(e) => setPageSize(parseInt(e.target.value, 10))}
+        size={size}
+        disableDefaultStyles={disableDefaultStyles}
+        className={customClassNames.pageSize?.select}
+      >
         {sizes.map((s, i) => (
           <option key={`${id}-option-${i}`} value={s}>
             {s}

--- a/packages/search-ui/src/PageSize/styles.ts
+++ b/packages/search-ui/src/PageSize/styles.ts
@@ -1,0 +1,11 @@
+import { mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+export default function usePageSizeStyles() {
+  const styles = {
+    container: [tw`flex items-center space-x-4`],
+    label: [tw`text-gray-500`],
+  };
+
+  return mapStyles(styles);
+}

--- a/packages/search-ui/src/PageSize/types.ts
+++ b/packages/search-ui/src/PageSize/types.ts
@@ -1,6 +1,6 @@
 import { BoxProps } from '@sajari/react-components';
 
-export interface PageSizeProps extends BoxProps {
+export interface PageSizeProps extends Omit<BoxProps, 'className'> {
   label?: string;
   sizes?: number[];
   size?: 'sm' | 'md' | 'lg';


### PR DESCRIPTION
Add options to control styles for PageSize component:

- [x] custom classNames at the context level
- [x] be able to completely disable the default styling