### PR TITLE
V3: fix filter bucket usage

### DIFF
--- a/docs/pages/search-ui/filter.mdx
+++ b/docs/pages/search-ui/filter.mdx
@@ -35,6 +35,7 @@ function Example() {
       HP: "brand = 'HP'",
       Garmin: "brand = 'Garmin'",
     },
+    count: false,
   });
 
   const priceFilter = new FilterBuilder({
@@ -44,6 +45,7 @@ function Example() {
       Mid: 'price >= 50',
       Low: 'price < 50',
     },
+    count: false,
     multi: false,
     initial: ['High'],
   });


### PR DESCRIPTION
## What this PR does
- [x] Update doc for bucket filter to work correctly

I think this is because there was a PR that made the `count` field `true` by default, so we forgot to check back all filters.