### PR TITLE
V3: add option to control styles for Swatch

### DIFF
--- a/packages/components/src/Swatch/color.tsx
+++ b/packages/components/src/Swatch/color.tsx
@@ -3,7 +3,7 @@
 import { jsx } from '@emotion/core';
 import { useSwitch } from '@react-aria/switch';
 import { useToggleState } from '@react-stately/toggle';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import classnames from 'classnames';
 import ColorClass from 'color';
 import React, { useCallback } from 'react';
@@ -11,35 +11,16 @@ import tw, { styled } from 'twin.macro';
 
 import { IconCheck } from '../assets/icons';
 import Box from '../Box';
-import { useFocusRingStyles } from '../hooks';
 import { colors } from './colors';
 import { useSwatchContext } from './context';
+import useColorStyles from './styles';
 import { ColorProps } from './types';
-
-const mapBorderRadius = (rounded: ColorProps['rounded']) => {
-  switch (rounded) {
-    case 'none':
-      return tw`rounded-none`;
-    case 'sm':
-      return tw`rounded-sm`;
-    case 'lg':
-      return tw`rounded-lg`;
-    case 'full':
-      return tw`rounded-full`;
-    default:
-    case 'md':
-      return tw`rounded-md`;
-  }
-};
 
 const StyledLabel = styled.label<{
   textColor: ColorProps['color'];
   bg: ColorProps['bg'];
   border: ColorProps['border'];
-  rounded: ColorProps['rounded'];
 }>`
-  ${tw`relative flex items-center justify-center mt-2 ml-2 border border-solid cursor-pointer w-7 h-7`}
-  ${({ rounded }) => mapBorderRadius(rounded)}
   color: ${({ textColor }) => textColor};
   background-color: ${({ bg }) => bg};
   border-color: ${({ border }) => border};
@@ -58,7 +39,7 @@ export const Color = (props: ColorProps) => {
     className,
   } = props;
   const ref = React.useRef<HTMLInputElement>(null);
-  const { state, setState } = useSwatchContext();
+  const { state, setState, disableDefaultStyles = false } = useSwatchContext();
   const toggleState = useToggleState();
   const checked = state.includes(id);
   const toggle = useCallback(() => setState(checked ? state.filter((i) => i !== id) : [...state, id]), [
@@ -75,15 +56,15 @@ export const Color = (props: ColorProps) => {
     ref,
   );
 
-  const { focusProps, focusRingStyles } = useFocusRingStyles({ color: border.toString() });
+  const { styles: colorStyles, focusProps } = useColorStyles({ border, checked, rounded });
+  const styles = getStylesObject(colorStyles, disableDefaultStyles);
 
   return (
     <StyledLabel
       bg={bg}
       border={border}
       textColor={color}
-      rounded={rounded}
-      css={focusRingStyles}
+      css={styles.container}
       className={classnames(className, { [checkedClassName]: checked })}
     >
       <Box as="span" css={tw`sr-only`}>
@@ -98,7 +79,7 @@ export const Color = (props: ColorProps) => {
         aria-checked={checked}
         onClick={toggle}
       />
-      <IconCheck css={checked ? tw`opacity-100 fill-current` : tw`opacity-0 fill-current`} />
+      <IconCheck css={styles.iconCheck} />
     </StyledLabel>
   );
 };

--- a/packages/components/src/Swatch/index.tsx
+++ b/packages/components/src/Swatch/index.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { __DEV__ } from '@sajari/react-sdk-utils';
+import { __DEV__, cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
+import { cloneElement } from 'react';
 import tw from 'twin.macro';
 
 import Box from '../Box';
@@ -13,16 +14,25 @@ const Swatch = ({
   children,
   checkedColors = [],
   onChange = () => {},
-  disableDefaultStyles = false,
   styles: stylesProp,
+  disableDefaultStyles = false,
+  colorCheckedClassName = '',
+  colorClassName = '',
   ...rest
-}: SwatchProps) => (
-  <SwatchContextProvider value={{ state: checkedColors, setState: onChange, disableDefaultStyles }}>
-    <Box css={[tw`flex flex-wrap -mt-2 -ml-2`, stylesProp]} {...rest}>
-      {children}
-    </Box>
-  </SwatchContextProvider>
-);
+}: SwatchProps) => {
+  const styles = getStylesObject({ container: tw`flex flex-wrap -mt-2 -ml-2` }, disableDefaultStyles);
+  const validChildren = cleanChildren(children);
+
+  return (
+    <SwatchContextProvider value={{ state: checkedColors, setState: onChange, disableDefaultStyles }}>
+      <Box css={[styles.container, stylesProp]} {...rest}>
+        {validChildren.map((child) =>
+          cloneElement(child, { className: colorClassName, checkedClassName: colorCheckedClassName, ...child.props }),
+        )}
+      </Box>
+    </SwatchContextProvider>
+  );
+};
 
 if (__DEV__) {
   Swatch.displayName = 'Swatch';

--- a/packages/components/src/Swatch/styles.tsx
+++ b/packages/components/src/Swatch/styles.tsx
@@ -1,0 +1,45 @@
+import { mapStyles } from '@sajari/react-sdk-utils';
+import tw from 'twin.macro';
+
+import { useFocusRingStyles } from '../hooks';
+import { ColorProps } from './types';
+
+interface UseColorStylesParams {
+  checked: boolean;
+  border: ColorProps['border'];
+  rounded: ColorProps['rounded'];
+}
+
+export default function useColorStyles(props: UseColorStylesParams) {
+  const { checked, border, rounded } = props;
+  const { focusProps, focusRingStyles } = useFocusRingStyles({ color: String(border) });
+
+  const styles = {
+    container: [
+      focusRingStyles,
+      tw`relative flex items-center justify-center mt-2 ml-2 border border-solid cursor-pointer w-7 h-7`,
+    ],
+    iconCheck: [checked ? tw`opacity-100 fill-current` : tw`opacity-0 fill-current`],
+  };
+
+  switch (rounded) {
+    case 'none':
+      styles.container.push(tw`rounded-none`);
+      break;
+    case 'sm':
+      styles.container.push(tw`rounded-sm`);
+      break;
+    case 'lg':
+      styles.container.push(tw`rounded-lg`);
+      break;
+    case 'full':
+      styles.container.push(tw`rounded-full`);
+      break;
+    default:
+    case 'md':
+      styles.container.push(tw`rounded-md`);
+      break;
+  }
+
+  return { styles: mapStyles(styles), focusProps };
+}

--- a/packages/components/src/Swatch/styles.tsx
+++ b/packages/components/src/Swatch/styles.tsx
@@ -1,7 +1,7 @@
 import { mapStyles } from '@sajari/react-sdk-utils';
 import tw from 'twin.macro';
 
-import { useFocusRingStyles } from '../hooks';
+import { useBorderRadius, useFocusRingStyles } from '../hooks';
 import { ColorProps } from './types';
 
 interface UseColorStylesParams {
@@ -13,33 +13,16 @@ interface UseColorStylesParams {
 export default function useColorStyles(props: UseColorStylesParams) {
   const { checked, border, rounded } = props;
   const { focusProps, focusRingStyles } = useFocusRingStyles({ color: String(border) });
+  const borderRadiusStyles = useBorderRadius({ rounded });
 
   const styles = {
     container: [
       focusRingStyles,
       tw`relative flex items-center justify-center mt-2 ml-2 border border-solid cursor-pointer w-7 h-7`,
+      borderRadiusStyles,
     ],
     iconCheck: [checked ? tw`opacity-100 fill-current` : tw`opacity-0 fill-current`],
   };
-
-  switch (rounded) {
-    case 'none':
-      styles.container.push(tw`rounded-none`);
-      break;
-    case 'sm':
-      styles.container.push(tw`rounded-sm`);
-      break;
-    case 'lg':
-      styles.container.push(tw`rounded-lg`);
-      break;
-    case 'full':
-      styles.container.push(tw`rounded-full`);
-      break;
-    default:
-    case 'md':
-      styles.container.push(tw`rounded-md`);
-      break;
-  }
 
   return { styles: mapStyles(styles), focusProps };
 }

--- a/packages/components/src/Swatch/types.ts
+++ b/packages/components/src/Swatch/types.ts
@@ -24,4 +24,8 @@ export interface SwatchProps extends BoxProps {
   onChange: (checkedColors: string[]) => void;
   /** Default checked colors */
   checkedColors?: string[];
+  /** The classname for color */
+  colorClassName?: string;
+  /** The classname for color that is being checked */
+  colorCheckedClassName?: string;
 }

--- a/packages/components/src/Swatch/types.ts
+++ b/packages/components/src/Swatch/types.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { BoxProps } from '../Box';
+import { BorderRadiusParams } from '../hooks';
 
 export interface ColorProps extends BoxProps {
   /** The identifier of the color */
@@ -12,7 +13,7 @@ export interface ColorProps extends BoxProps {
   /** Border color, defaults to background color */
   border?: string;
   /** Border radius */
-  rounded?: 'sm' | 'md' | 'lg' | 'full' | 'none';
+  rounded?: BorderRadiusParams['rounded'];
   /** The classname for the color box being checked */
   checkedClassName?: string;
 }

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -1,3 +1,5 @@
+export * from './useBorderRadius';
+export { default as useBorderRadius } from './useBorderRadius';
 export { default as useFocusRingStyles } from './useFocusRingStyles';
 export * from './useFocusRingStyles';
 export { default as useFontSize } from './useFontSize';

--- a/packages/components/src/hooks/useBorderRadius.ts
+++ b/packages/components/src/hooks/useBorderRadius.ts
@@ -1,0 +1,34 @@
+import { css } from '@emotion/core';
+import tw, { TwStyle } from 'twin.macro';
+
+export type RoundedSizes = 'sm' | 'md' | 'lg' | 'full' | 'none';
+
+export interface BorderRadiusParams {
+  rounded?: RoundedSizes;
+}
+
+export default function useBorderRadius(props: BorderRadiusParams) {
+  const { rounded } = props;
+  const styles: TwStyle[] = [];
+
+  switch (rounded) {
+    case 'none':
+      styles.push(tw`rounded-none`);
+      break;
+    case 'sm':
+      styles.push(tw`rounded-sm`);
+      break;
+    case 'lg':
+      styles.push(tw`rounded-lg`);
+      break;
+    case 'full':
+      styles.push(tw`rounded-full`);
+      break;
+    default:
+    case 'md':
+      styles.push(tw`rounded-md`);
+      break;
+  }
+
+  return css(styles);
+}


### PR DESCRIPTION
Add options to control styles for Swatch component:

- [x] control classNames of `Color` component via the parent `Swatch`.
- [x] be able to completely disable the default styling.