### PR TITLE
V3: add onSelect handler to useAutocomplete docs

### DIFF
--- a/docs/pages/hooks/useautocomplete.mdx
+++ b/docs/pages/hooks/useautocomplete.mdx
@@ -22,25 +22,20 @@ function Example() {
 
   return (
     <div className="flex flex-col space-y-3">
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          const formData = new FormData(e.target);
-          search(formData.get('query'));
+      <Combobox
+        mode="suggestions"
+        name="query"
+        label="Query"
+        value={query}
+        items={suggestions}
+        onChange={(value) => {
+          setQuery(value);
+          searchInstant(value);
         }}
-      >
-        <Combobox
-          mode="suggestions"
-          name="query"
-          label="Query"
-          value={query}
-          items={suggestions}
-          onChange={(value) => {
-            setQuery(value);
-            searchInstant(value);
-          }}
-        />
-      </form>
+        onSelect={(value) => {
+          search(value);
+        }}
+      />
       {results && <Results />}
     </div>
   );


### PR DESCRIPTION
## What this PR does
 - [x] Add `onSelect` handler because we're using `Combobox` and not `Input`