### PR TITLE
V3: add plugin to autogenerate props table

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,5 +1,24 @@
+const path = require('path');
+const fs = require('fs');
 /* eslint-disable global-require */
 const remarkPlugins = [
+  [
+    require('remark-props-table'),
+    {
+      // This will be called for each mdx file and we must return the component's file path in order for the docgen to find and parse it
+      pathResolver: (filePath) => {
+        const componentName = filePath.split('/').slice(-1)[0].replace('.mdx', '');
+        const regex = /\/pages\/(.*)\//g;
+        const matches = regex.exec(filePath) || [];
+        const package = String(matches[1]);
+        const resolved = path.resolve(filePath, `../../../../packages/${package}/src/${componentName}/index.tsx`);
+        if (!fs.existsSync(resolved)) {
+          return '';
+        }
+        return resolved;
+      },
+    },
+  ],
   require('remark-autolink-headings'),
   require('remark-emoji'),
   require('remark-images'),

--- a/packages/remark-props-table/index.js
+++ b/packages/remark-props-table/index.js
@@ -1,0 +1,120 @@
+const heading = require('mdast-util-heading-range');
+const fs = require('fs');
+const { parse, importers } = require('react-docgen');
+const fromMarkdown = require('mdast-util-from-markdown');
+
+const headingOptions = {
+  ignoreFinalDefinitions: true,
+  test: 'props table',
+};
+
+const inlineCode = (value) => {
+  return {
+    type: 'inlineCode',
+    value,
+  };
+};
+
+const cell = (children) => {
+  return {
+    type: 'tableCell',
+    children,
+  };
+};
+
+const text = (value) => {
+  return {
+    type: 'text',
+    value,
+  };
+};
+
+const row = (name, type, description) => {
+  // Parse from props comment into MDAST (markdown AST), then get the children of each "paragraph" node and flatten it
+  const parsedDescription = fromMarkdown(description)
+    .children.map((c) => {
+      if (c.type === 'paragraph') {
+        return c.children;
+      }
+      return c;
+    })
+    .flat(1);
+
+  return {
+    type: 'tableRow',
+    children: [cell([inlineCode(name)]), cell([inlineCode(type)]), cell([]), cell(parsedDescription)],
+  };
+};
+
+const header = () => {
+  return {
+    type: 'tableRow',
+    children: [cell([text('Name')]), cell([text('Type')]), cell([text('Default')]), cell([text('Description')])],
+  };
+};
+
+const rows = (types) => {
+  return Object.entries(types)
+    .map(([props, info]) => {
+      if (props === 'children' || props === 'styles') {
+        return undefined;
+      }
+
+      const {
+        tsType: { name, raw },
+        description,
+      } = info;
+
+      return row(props, raw || name, description);
+    })
+    .filter(Boolean);
+};
+
+// Entry
+function propsTable(options) {
+  if (!options || (options && !options.pathResolver)) {
+    throw new Error('pathResolver must be specified');
+  }
+
+  let componentPath = '';
+  let types = {};
+
+  function onHeading(start, nodes, end) {
+    // Inject an additional table node into the mdx file
+    return [
+      start,
+      ...nodes,
+      {
+        type: 'table',
+        children: [header(), ...rows(types)],
+      },
+      end,
+    ];
+  }
+
+  function transformer(tree, file) {
+    try {
+      componentPath = options.pathResolver(file.path);
+      if (!componentPath) {
+        return;
+      }
+      const componentContent = fs.readFileSync(componentPath, { encoding: 'utf-8' });
+      // Get the props type object
+      types =
+        parse(componentContent, null, null, {
+          importer: importers.makeFsImporter(),
+          filename: componentPath,
+          babelrc: false,
+        }).props || {};
+
+      // remark plugin to scan the mdx and run `onHeading` whenever it sees a heading that matches the criteria
+      heading(tree, headingOptions, onHeading);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return transformer;
+}
+
+module.exports = propsTable;

--- a/packages/remark-props-table/package.json
+++ b/packages/remark-props-table/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "remark-props-table",
+  "version": "1.0.0",
+  "private": "true",
+  "description": "",
+  "main": "index.js",
+  "keywords": [],
+  "files": [
+    "index.js"
+  ],
+  "dependencies": {
+    "mdast-util-from-markdown": "^0.8.1",
+    "mdast-util-heading-range": "^2.1.5",
+    "react-docgen": "^5.4.0-alpha.0"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,7 +1649,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.12.5", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5":
+"@babel/runtime@7.12.5", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
@@ -4896,6 +4896,13 @@ ast-types@0.13.2:
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
   integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
 
+ast-types@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -6046,7 +6053,7 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@^2.17.1, commander@^2.20.0:
+commander@^2.17.1, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -6675,6 +6682,13 @@ debug@^3.1.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.0.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -10998,6 +11012,23 @@ mdast-util-definitions@^3.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-from-markdown@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.1.tgz#781371d493cac11212947226190270c15dc97116"
+  integrity sha512-qJXNcFcuCSPqUF0Tb0uYcFDIq67qwB3sxo9RPdf9vG8T90ViKnksFqdB/Coq2a7sTnxL/Ify2y7aIQXDkQFH0w==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^1.0.0"
+    micromark "~2.10.0"
+    parse-entities "^2.0.0"
+
+mdast-util-heading-range@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-heading-range/-/mdast-util-heading-range-2.1.5.tgz#9a8e07bd46d07d40ad1596b0b6ab8535337725c3"
+  integrity sha512-jXbFD0C+MfRkwsaze+btzG9CmVrxnc5kpcJLtx3SvSlPWnNdGMlDRHKDB9/TIPEq9nRHnkixppT8yvaUJ5agJg==
+  dependencies:
+    mdast-util-to-string "^1.0.0"
+
 mdast-util-to-hast@9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-9.1.2.tgz#10fa5ed9d45bf3755891e5801d0f32e2584a9423"
@@ -11106,6 +11137,14 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
+micromark@~2.10.0:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.10.1.tgz#cd73f54e0656f10e633073db26b663a221a442a7"
+  integrity sha512-fUuVF8sC1X7wsCS29SYQ2ZfIZYbTymp0EYr6sab3idFjigFFjGa5UwoniPlV9tAgntjuapW1t9U+S0yDYeGKHQ==
+  dependencies:
+    debug "^4.0.0"
+    parse-entities "^2.0.0"
+
 micromatch@4.x, micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
@@ -11193,7 +11232,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -11481,6 +11520,13 @@ node-addon-api@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.2.tgz#04bc7b83fd845ba785bb6eae25bc857e1ef75681"
   integrity sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==
+
+node-dir@^0.1.10:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
+  integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
+  dependencies:
+    minimatch "^3.0.2"
 
 node-emoji@^1.10.0, node-emoji@^1.8.1:
   version "1.10.0"
@@ -12853,6 +12899,21 @@ react-clientside-effect@^1.2.2:
   integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
   dependencies:
     "@babel/runtime" "^7.0.0"
+
+react-docgen@^5.4.0-alpha.0:
+  version "5.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.4.0-alpha.0.tgz#e4c733c38f07624b0c3a220e02b7c032f84c326d"
+  integrity sha512-I0xT8wuYTCLXu0Muk02hTHfG+2P9QjFH7ljTqnfHZCGvpadD3mKGt3Egh85pq4iAB1TfBDELR+bbp1h9rDlARA==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/runtime" "^7.7.6"
+    ast-types "^0.14.2"
+    commander "^2.19.0"
+    doctrine "^3.0.0"
+    neo-async "^2.6.1"
+    node-dir "^0.1.10"
+    resolve "^1.17.0"
+    strip-indent "^3.0.0"
 
 react-dom@^17.0.1:
   version "17.0.1"
@@ -15048,7 +15109,7 @@ tslib@2.0.1, tslib@^2.0.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@2.0.3:
+tslib@2.0.3, tslib@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==


### PR DESCRIPTION
## Why
Because manually documenting props is a tedious task.

## What this PR does
- [x] Add a private package `remark-props-table` that allows us to hook into the mdx transform and inject a component's props table into the file.

## How to enable it
Inside any `.mdx` file, simply insert a `## Props Table` at the end of the file and the plugin will pick it up

## Caveats
* Apparently the docgen parser couldn't parse props where `PropsWithAs` is involved, take for example `Button` and `Image` component.
* Default props value can't also be picked up due to the face that we're using a function with default param syntax. One way we could do is to add `Component.defaultProps = {}`, that way the default props value will be populated.