### PR TITLE
V3: rating filter improvement

### DIFF
--- a/packages/search-ui/src/Filter/RatingFilter.tsx
+++ b/packages/search-ui/src/Filter/RatingFilter.tsx
@@ -1,5 +1,5 @@
 import { Rating } from '@sajari/react-components';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useSearchUIContext } from '../ContextProvider';
 import ListFilter from './ListFilter';
@@ -8,13 +8,9 @@ import { RatingFilterProps } from './types';
 const RatingFilter = ({ name, title }: Omit<RatingFilterProps, 'type'>) => {
   const { ratingMax, disableDefaultStyles, customClassNames } = useSearchUIContext();
 
-  return (
-    <ListFilter
-      name={name}
-      title={title}
-      sort="none"
-      pinSelected={false}
-      itemRender={(v) => (
+  const renderRating = useCallback(
+    (v: string) => {
+      return (
         <Rating
           max={ratingMax}
           className={customClassNames.filter?.rating?.container}
@@ -23,9 +19,12 @@ const RatingFilter = ({ name, title }: Omit<RatingFilterProps, 'type'>) => {
           value={Number(v)}
           disableDefaultStyles={disableDefaultStyles}
         />
-      )}
-    />
+      );
+    },
+    [ratingMax, JSON.stringify(customClassNames.filter?.rating), disableDefaultStyles],
   );
+
+  return <ListFilter name={name} title={title} sort="none" pinSelected={false} itemRender={renderRating} />;
 };
 
 export default RatingFilter;


### PR DESCRIPTION
## Why
`ListFilter` is rerendering multiple times because of anonymous function `itemRender` -> poor performance.

## What this PR does
- [x] Wrap the render prop in `useCallback` to avoid unnecessary rerenders