### PR TITLE
chore: remove emotion jsx pragma

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [["@babel/preset-react", { "runtime": "automatic", "importSource": "@emotion/core" }]],
+  "plugins": [["babel-plugin-emotion", { "cssPropOptimization": true }]]
+}

--- a/jest/jest-preprocess.js
+++ b/jest/jest-preprocess.js
@@ -1,6 +1,5 @@
-/* eslint-disable import/no-extraneous-dependencies */
 const babelOptions = {
-  presets: ['@babel/env', '@babel/preset-react', '@babel/preset-typescript'],
+  presets: ['@babel/env', '@babel/preset-react', '@emotion/babel-preset-css-prop', '@babel/preset-typescript'],
   plugins: ['babel-plugin-macros'],
 };
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.12.10",
     "@babel/preset-typescript": "^7.12.7",
+    "@emotion/babel-preset-css-prop": "^10.0.23",
     "@emotion/jest": "^11.1.0",
     "@svgr/rollup": "^5.5.0",
     "@testing-library/dom": "^7.29.0",

--- a/packages/components/.babelrc
+++ b/packages/components/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.babelrc"
+}

--- a/packages/components/src/AspectRatio/index.tsx
+++ b/packages/components/src/AspectRatio/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { forwardRefWithAs, getStylesObject, PropsWithAs } from '@sajari/react-sdk-utils';
 import React, { Children, cloneElement, isValidElement } from 'react';
 

--- a/packages/components/src/Button/index.tsx
+++ b/packages/components/src/Button/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useButton } from '@react-aria/button';
 import { useFocus, useHover } from '@react-aria/interactions';
 import { mergeProps } from '@react-aria/utils';

--- a/packages/components/src/ButtonGroup/index.tsx
+++ b/packages/components/src/ButtonGroup/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-nested-ternary */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { __DEV__, cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement } from 'react';
 import tw, { styled } from 'twin.macro';

--- a/packages/components/src/Checkbox/index.tsx
+++ b/packages/components/src/Checkbox/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';

--- a/packages/components/src/CheckboxGroup/index.tsx
+++ b/packages/components/src/CheckboxGroup/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import { cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement, useRef, useState } from 'react';

--- a/packages/components/src/Combobox/components/Dropdown/index.tsx
+++ b/packages/components/src/Combobox/components/Dropdown/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/Combobox/components/DropdownItem/index.tsx
+++ b/packages/components/src/Combobox/components/DropdownItem/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import classnames from 'classnames';
 import React from 'react';

--- a/packages/components/src/Combobox/components/DropdownResult/index.tsx
+++ b/packages/components/src/Combobox/components/DropdownResult/index.tsx
@@ -1,7 +1,6 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import classnames from 'classnames';
+import React from 'react';
 
 import Box from '../../../Box';
 import Heading from '../../../Heading';

--- a/packages/components/src/Combobox/components/Typeahead/index.tsx
+++ b/packages/components/src/Combobox/components/Typeahead/index.tsx
@@ -1,6 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
+import React from 'react';
 
 import Box from '../../../Box';
 import { useComboboxContext } from '../../context';

--- a/packages/components/src/Combobox/components/Voice/index.tsx
+++ b/packages/components/src/Combobox/components/Voice/index.tsx
@@ -1,6 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
+import React from 'react';
 
 import { IconEmptyMic, IconMic } from '../../../assets/icons';
 import Box from '../../../Box';

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable prefer-arrow-callback */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { mergeProps, useId } from '@react-aria/utils';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import { useCombobox } from 'downshift';

--- a/packages/components/src/Heading/index.tsx
+++ b/packages/components/src/Heading/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { forwardRefWithAs, getStylesObject, PropsWithAs } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/Image/index.tsx
+++ b/packages/components/src/Image/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/Label/index.tsx
+++ b/packages/components/src/Label/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/Link/index.tsx
+++ b/packages/components/src/Link/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { mergeProps } from '@react-aria/utils';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';

--- a/packages/components/src/Pagination/index.tsx
+++ b/packages/components/src/Pagination/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { clamp, getStylesObject, isSSR, isString } from '@sajari/react-sdk-utils';
 import classnames from 'classnames';
 import React, { useCallback, useEffect } from 'react';

--- a/packages/components/src/PoweredBy/index.tsx
+++ b/packages/components/src/PoweredBy/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { __DEV__ } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/Radio/index.tsx
+++ b/packages/components/src/Radio/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/role-supports-aria-props */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { useId } from '@react-aria/utils';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';

--- a/packages/components/src/RadioGroup/index.tsx
+++ b/packages/components/src/RadioGroup/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import { cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement, forwardRef, useImperativeHandle, useRef, useState } from 'react';

--- a/packages/components/src/RangeInput/components/Fill/index.tsx
+++ b/packages/components/src/RangeInput/components/Fill/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/RangeInput/components/Handle/index.tsx
+++ b/packages/components/src/RangeInput/components/Handle/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import classnames from 'classnames';
 import React from 'react';

--- a/packages/components/src/RangeInput/components/Input/index.tsx
+++ b/packages/components/src/RangeInput/components/Input/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { useTextField } from '@react-aria/textfield';
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';

--- a/packages/components/src/RangeInput/components/Track/index.tsx
+++ b/packages/components/src/RangeInput/components/Track/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/RangeInput/index.tsx
+++ b/packages/components/src/RangeInput/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { AriaTextFieldOptions, useTextField } from '@react-aria/textfield';
 import { __DEV__, clamp, closest, formatNumber, getStylesObject, round } from '@sajari/react-sdk-utils';
 import React, { MouseEvent, ReactNode, useEffect } from 'react';

--- a/packages/components/src/Rating/RatingItem.tsx
+++ b/packages/components/src/Rating/RatingItem.tsx
@@ -1,6 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { getStylesObject } from '@sajari/react-sdk-utils';
+import React from 'react';
 
 import Box from '../Box';
 import useRatingItemStyles from './styles';

--- a/packages/components/src/Rating/index.tsx
+++ b/packages/components/src/Rating/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import classnames from 'classnames';
 import React from 'react';

--- a/packages/components/src/ResizeObserver/index.tsx
+++ b/packages/components/src/ResizeObserver/index.tsx
@@ -1,7 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { __DEV__, isSSR } from '@sajari/react-sdk-utils';
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import Observer from 'resize-observer-polyfill';
 
 import Box from '../Box';

--- a/packages/components/src/Select/index.tsx
+++ b/packages/components/src/Select/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import React from 'react';

--- a/packages/components/src/Spinner/index.tsx
+++ b/packages/components/src/Spinner/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { __DEV__ } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/Swatch/color.tsx
+++ b/packages/components/src/Swatch/color.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-confusing-arrow */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { useSwitch } from '@react-aria/switch';
 import { useToggleState } from '@react-stately/toggle';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';

--- a/packages/components/src/Swatch/index.tsx
+++ b/packages/components/src/Swatch/index.tsx
@@ -1,7 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { __DEV__, cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
-import { cloneElement, useCallback } from 'react';
+import React, { cloneElement, useCallback } from 'react';
 import tw from 'twin.macro';
 
 import Box from '../Box';

--- a/packages/components/src/Tabs/Tab/index.tsx
+++ b/packages/components/src/Tabs/Tab/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { mergeProps } from '@react-aria/utils';
 import { __DEV__, getStylesObject } from '@sajari/react-sdk-utils';
 import classnames from 'classnames';

--- a/packages/components/src/Tabs/TabList/index.tsx
+++ b/packages/components/src/Tabs/TabList/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { __DEV__, cleanChildren, getStylesObject } from '@sajari/react-sdk-utils';
 import React, { cloneElement, useRef } from 'react';
 

--- a/packages/components/src/Tabs/TabPanel/index.tsx
+++ b/packages/components/src/Tabs/TabPanel/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { __DEV__, assignRef } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/src/Tabs/TabPanels/index.tsx
+++ b/packages/components/src/Tabs/TabPanels/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { __DEV__, cleanChildren } from '@sajari/react-sdk-utils';
 import React, { cloneElement } from 'react';
 

--- a/packages/components/src/Tabs/index.tsx
+++ b/packages/components/src/Tabs/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import React, { useRef, useState } from 'react';
 

--- a/packages/components/src/Text/index.tsx
+++ b/packages/components/src/Text/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { forwardRefWithAs, getStylesObject, PropsWithAs } from '@sajari/react-sdk-utils';
 import React from 'react';
 

--- a/packages/components/tsconfig.build.json
+++ b/packages/components/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.build.json",
   "files": ["./src/types/twin.d.ts"],
+  "compilerOptions": {
+    "jsx": "preserve"
+  },
   "include": ["src", "types", "../../types"]
 }

--- a/packages/search-ui/.babelrc
+++ b/packages/search-ui/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "../../.babelrc"
+}

--- a/packages/search-ui/src/Filter/Box.tsx
+++ b/packages/search-ui/src/Filter/Box.tsx
@@ -1,6 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { Box as CoreBox } from '@sajari/react-components';
+import React from 'react';
 
 import { useSearchUIContext } from '../ContextProvider';
 import Header from './Header';

--- a/packages/search-ui/src/Filter/Header.tsx
+++ b/packages/search-ui/src/Filter/Header.tsx
@@ -1,7 +1,6 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { Box, Button, Heading } from '@sajari/react-components';
 import { getStylesObject } from '@sajari/react-sdk-utils';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import tw from 'twin.macro';
 

--- a/packages/search-ui/src/Filter/ListFilter.tsx
+++ b/packages/search-ui/src/Filter/ListFilter.tsx
@@ -1,9 +1,7 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { Box as CoreBox, Button, Checkbox, CheckboxGroup, Combobox, Radio, RadioGroup } from '@sajari/react-components';
 import { useFilter, useQuery } from '@sajari/react-hooks';
 import { getStylesObject, isBoolean, isEmpty, useTheme } from '@sajari/react-sdk-utils';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import tw from 'twin.macro';
 

--- a/packages/search-ui/src/Filter/TabFilter.tsx
+++ b/packages/search-ui/src/Filter/TabFilter.tsx
@@ -1,8 +1,7 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { Tab, TabList, Tabs } from '@sajari/react-components';
 import { useFilter } from '@sajari/react-hooks';
 import { isEmpty } from '@sajari/react-sdk-utils';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../ContextProvider';

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { Combobox } from '@sajari/react-components';
 import { useAutocomplete, useQuery, useSearchContext } from '@sajari/react-hooks';
 import { __DEV__ } from '@sajari/react-sdk-utils';

--- a/packages/search-ui/src/Results/components/Message/index.tsx
+++ b/packages/search-ui/src/Results/components/Message/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { Box, Heading, Spinner, Text } from '@sajari/react-components';
 import { getStylesObject } from '@sajari/react-sdk-utils';
 import * as React from 'react';

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/jsx-no-target-blank */
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
+
 import { Box, Heading, Image, ImageProps, Link, Rating, Text } from '@sajari/react-components';
 import {
   __DEV__,

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -1,5 +1,3 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { ResizeObserver } from '@sajari/react-components';
 import { useQuery, useSearchContext, useTracking } from '@sajari/react-hooks';
 import { getStylesObject, isEmpty, isNullOrUndefined } from '@sajari/react-sdk-utils';

--- a/packages/search-ui/src/ResultsPerPage/index.tsx
+++ b/packages/search-ui/src/ResultsPerPage/index.tsx
@@ -1,8 +1,7 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import { Select } from '@sajari/react-components';
 import { useResultsPerPage, useSearchContext } from '@sajari/react-hooks';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../ContextProvider';

--- a/packages/search-ui/src/Sorting/index.tsx
+++ b/packages/search-ui/src/Sorting/index.tsx
@@ -1,8 +1,7 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import { Select } from '@sajari/react-components';
 import { useSorting } from '@sajari/react-hooks';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../ContextProvider';

--- a/packages/search-ui/src/ViewType/index.tsx
+++ b/packages/search-ui/src/ViewType/index.tsx
@@ -1,8 +1,7 @@
-/** @jsx jsx */
-import { jsx } from '@emotion/core';
 import { useId } from '@react-aria/utils';
 import { Button, ButtonGroup } from '@sajari/react-components';
 import { useSearchContext } from '@sajari/react-hooks';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { IconSmallGrid, IconSmallList } from '../assets/icons';

--- a/packages/search-ui/tsconfig.build.json
+++ b/packages/search-ui/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.build.json",
   "files": ["./src/types/twin.d.ts"],
+  "compilerOptions": {
+    "jsx": "preserve"
+  },
   "include": ["src", "types", "../../types"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -207,6 +207,15 @@
     "@babel/helper-module-imports" "^7.12.5"
     "@babel/types" "^7.12.10"
 
+"@babel/helper-builder-react-jsx-experimental@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.11.tgz#a39616d7e4cf8f9da1f82b5fc3ee1f7406beeb11"
+  integrity sha512-4oGVOekPI8dh9JphkPXC68iIuP6qp/RPbaPmorRmEFbRAHZjSqxPjqHudn18GVDPgCuFM/KdFXc63C17Ygfa9w==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.12.10"
+    "@babel/helper-module-imports" "^7.12.5"
+    "@babel/types" "^7.12.11"
+
 "@babel/helper-builder-react-jsx-experimental@^7.12.4":
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz#55fc1ead5242caa0ca2875dcb8eed6d311e50f48"
@@ -500,6 +509,11 @@
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
 
 "@babel/helper-validator-option@^7.12.1":
   version "7.12.1"
@@ -833,7 +847,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@7.12.1", "@babel/plugin-syntax-jsx@^7.12.1":
+"@babel/plugin-syntax-jsx@7.12.1", "@babel/plugin-syntax-jsx@^7.12.1", "@babel/plugin-syntax-jsx@^7.2.0":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz#9d9d357cc818aa7ae7935917c1257f67677a0926"
   integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
@@ -1285,6 +1299,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-react-jsx-development@^7.12.1":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.11.tgz#078aa7e1f5f75a68ee9598ebed90000fcb11092f"
+  integrity sha512-5MvsGschXeXJsbzQGR/BH89ATMzCsM7rx95n+R7/852cGoK2JgMbacDw/A9Pmrfex4tArdMab0L5SBV4SB/Nxg==
+  dependencies:
+    "@babel/helper-builder-react-jsx-experimental" "^7.12.11"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-jsx" "^7.12.1"
+
 "@babel/plugin-transform-react-jsx-development@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.5.tgz#677de5b96da310430d6cfb7fee16a1603afa3d56"
@@ -1316,6 +1339,16 @@
   integrity sha512-keQ5kBfjJNRc6zZN1/nVHCd6LLIHq4aUKcVnvE/2l+ZZROSbqoiGFRtT5t3Is89XJxBQaP7NLZX2jgGHdZvvFQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-react-jsx@^7.12.1":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.11.tgz#09a7319195946b0ddc09f9a5f01346f2cb80dfdd"
+  integrity sha512-5nWOw6mTylaFU72BdZfa0dP1HsGdY3IMExpxn8LBE8dNmkQjB+W+sR+JwIdtbzkPvVuFviT3zyNbSUkuVTVxbw==
+  dependencies:
+    "@babel/helper-builder-react-jsx" "^7.10.4"
+    "@babel/helper-builder-react-jsx-experimental" "^7.12.11"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-jsx" "^7.12.1"
 
 "@babel/plugin-transform-react-jsx@^7.12.10":
   version "7.12.10"
@@ -1813,6 +1846,15 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.11.tgz#a86e4d71e30a9b6ee102590446c98662589283ce"
+  integrity sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.12.5", "@babel/types@^7.12.6":
   version "7.12.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
@@ -1843,6 +1885,24 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
+
+"@emotion/babel-plugin-jsx-pragmatic@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.5.tgz#27debfe9c27c4d83574d509787ae553bf8a34d7e"
+  integrity sha512-y+3AJ0SItMDaAgGPVkQBC/S/BaqaPACkQ6MyCI2CUlrjTxKttTVfD3TMtcs7vLEcLxqzZ1xiG0vzwCXjhopawQ==
+  dependencies:
+    "@babel/plugin-syntax-jsx" "^7.2.0"
+
+"@emotion/babel-preset-css-prop@^10.0.23":
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.2.1.tgz#fb331355c1819367a6e5dd171879ae4957aa701a"
+  integrity sha512-4hudLJCfIrbpJZek5n69cwzu7GgCamza/whh/RgqXaI5ZWT8pFj1rR2KjQntzFFzTU7l9o+jdVPSpgCbrVG+VQ==
+  dependencies:
+    "@babel/plugin-transform-react-jsx" "^7.12.1"
+    "@babel/plugin-transform-react-jsx-development" "^7.12.1"
+    "@babel/runtime" "^7.5.5"
+    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.5"
+    babel-plugin-emotion "^10.0.27"
 
 "@emotion/cache@^10.0.27":
   version "10.0.29"


### PR DESCRIPTION
Use `@emotion/babel-preset-css-prop` so we don't have to include `/** @jsx jsx */` in every component.