### PR TITLE
V3: add hover functionality to image

### DIFF
--- a/docs/pages/components/image.mdx
+++ b/docs/pages/components/image.mdx
@@ -24,11 +24,26 @@ This is useful if you want to crop the image or you don't know the dimensions of
 <Image src="https://source.unsplash.com/random" alt="Unplash photo" aspectRatio={1} objectFit="cover" />
 ```
 
+### Change image on hover
+
+You can also provide an additional image under `hoverSrc` to change image on hover.
+
+```jsx
+<Image
+  src="https://source.unsplash.com/random"
+  hoverSrc="https://source.unsplash.com/user/erondu?1"
+  alt="Unplash photo"
+  aspectRatio={1}
+  objectFit="cover"
+/>
+```
+
 ## Props
 
 | Name          | Type                                                               | Default | Description                                                     |
 | ------------- | ------------------------------------------------------------------ | ------- | --------------------------------------------------------------- |
 | `src`         | `string`                                                           |         | The path to the image source.                                   |
+| `hoverSrc`    | `string`                                                           |         | The additional image to show when hovering.                     |
 | `alt`         | `string`                                                           |         | The alt text that describes the image.                          |
 | `onLoad`      | `function`                                                         |         | A callback for when the image `src` has been loaded.            |
 | `onError`     | `function`                                                         |         | A callback for when there was an error loading the image `src`. |

--- a/packages/components/src/Image/index.tsx
+++ b/packages/components/src/Image/index.tsx
@@ -22,8 +22,11 @@ const NativeImage = React.forwardRef((props: NativeImageProps, ref?: React.Ref<H
 const Image = React.forwardRef((props: ImageProps, ref?: React.Ref<HTMLImageElement>) => {
   const {
     src,
+    hoverSrc,
     onError,
     onLoad,
+    onMouseEnter: onMouseEnterExternal,
+    onMouseLeave: onMouseLeaveExternal,
     htmlWidth,
     htmlHeight,
     aspectRatio,
@@ -33,13 +36,39 @@ const Image = React.forwardRef((props: ImageProps, ref?: React.Ref<HTMLImageElem
     disableDefaultStyles = false,
     ...rest
   } = props;
-  const imageProps = { src, onLoad, onError, htmlWidth, htmlHeight };
-  const styles = getStylesObject(useImageStyles(props), disableDefaultStyles);
+  const [hover, setHover] = React.useState(false);
+  const onMouseEnter = (e) => {
+    if (hoverSrc) {
+      setHover(true);
+    }
+    onMouseEnterExternal?.(e);
+  };
+  const onMouseLeave = (e) => {
+    if (hoverSrc) {
+      setHover(false);
+    }
+
+    onMouseLeaveExternal?.(e);
+  };
+  const imageProps = {
+    src,
+    onLoad,
+    onError,
+    htmlWidth,
+    htmlHeight,
+    onMouseEnter,
+    onMouseLeave,
+  };
+  const styles = getStylesObject(useImageStyles({ ...props, hover }), disableDefaultStyles);
   const image = <Box as={NativeImage} ref={ref} css={styles.image} {...imageProps} {...rest} />;
+  const secondImage = React.cloneElement(image, { src: hoverSrc, css: styles.secondImage });
 
   return (
     <AspectRatio ratio={aspectRatio ?? null} css={styles.container} className={containerClassName}>
-      {src ? image : null}
+      <>
+        {src ? image : null}
+        {hoverSrc ? secondImage : null}
+      </>
     </AspectRatio>
   );
 });

--- a/packages/components/src/Image/types.ts
+++ b/packages/components/src/Image/types.ts
@@ -20,6 +20,8 @@ interface Props extends BoxProps {
   objectFit?: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
   /** The classname for  AspectRatio container wrapper */
   containerClassName?: string;
+  /** The image sources, pass in an array to display the second image on hover */
+  hoverSrc?: string;
 }
 
 export interface ImageProps extends HtmlAttributes, Props {}

--- a/packages/components/src/Image/useImageStyles.ts
+++ b/packages/components/src/Image/useImageStyles.ts
@@ -4,13 +4,19 @@ import tw from 'twin.macro';
 import { ImageProps } from './types';
 import { useHasImageLoaded } from './useHasImageLoaded';
 
-export function useImageStyles(props: ImageProps) {
+export function useImageStyles(props: ImageProps & { hover: boolean }) {
   const hasLoaded = useHasImageLoaded(props);
+  const { hover } = props;
   const styles = {
-    container: [tw`rounded-md`, !hasLoaded ? tw`bg-gray-100` : ''],
+    container: [tw`rounded-md relative`, !hasLoaded ? tw`bg-gray-100` : ''],
     image: [
       tw`transition-opacity duration-200 ease-in`,
-      hasLoaded ? tw`opacity-100` : tw`opacity-0`,
+      hasLoaded && !hover ? tw`opacity-100` : tw`opacity-0`,
+      { borderRadius: 'inherit' },
+    ],
+    secondImage: [
+      tw`transition-opacity duration-200 ease-in absolute top-0 left-0 w-full h-full`,
+      hasLoaded && hover ? tw`opacity-100` : tw`opacity-0`,
       { borderRadius: 'inherit' },
     ],
   };


### PR DESCRIPTION
## What this PR does:
- [x] Add a new prop `hoverSrc` that will show a second image when hovered on.

There is a particular weird bug where specifying `src` as an array results in images not loading despite having correct `src` attributes, hence the `hoverSrc` prop.
Also I think changing the type of `src` would potentially break current consumer of the sdk's code.

As for the changes to fields mapping, I've not seen any search results that have 2 images so I'll need to test that out first.

P.S: naming is hard so if you have anything better than `hoverSrc` feel free to throw it up here!