### PR TITLE
fix: release action run failed

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.3.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "https://github.com/sajari/sdk-react" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "sajari/sdk-react" }],
   "commit": false,
   "linked": [],
   "access": "public",


### PR DESCRIPTION
Fix release action run failed due to providing a wrong config setting for `changesets` - https://github.com/sajari/sdk-react/runs/1668436313?check_suite_focus=true

![image](https://user-images.githubusercontent.com/12707960/104054040-ec300a80-521e-11eb-883e-b03dfc3b4dd7.png)
