### PR TITLE
feat: support setting default value for viewType

### DIFF
--- a/.changeset/itchy-mirrors-roll.md
+++ b/.changeset/itchy-mirrors-roll.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': minor
+'@sajari/react-hooks': patch
+---
+
+Supported to set a default value for `viewType`. Also, moved viewType state from `hooks` package to `search-ui` package so leaving the hooks to only be in charge of handling data from the backend.

--- a/packages/hooks/src/ContextProvider/index.tsx
+++ b/packages/hooks/src/ContextProvider/index.tsx
@@ -26,7 +26,6 @@ import {
   PipelineProviderState,
   ProviderPipelineConfig,
   ProviderPipelineState,
-  ResultViewType,
   SearchProviderValues,
 } from './types';
 
@@ -103,7 +102,6 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
   const [autocompleteSearching, setAutocompleteSearching] = useState(false);
   const [searchState, setSearchState] = useState({ ...defaultState, response: initialResponse });
   const [autocompleteState, setAutocompleteState] = useState(defaultState);
-  const [viewType, setViewType] = useState<ResultViewType>('list');
   const [configDone, setConfigDone] = useState(false);
   const searchTimer = useRef<ReturnType<typeof setTimeout>>();
   const searchAutocompleteTimer = useRef<ReturnType<typeof setTimeout>>();
@@ -327,8 +325,6 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
       },
       resultClicked: handleResultClicked,
       paginate: handlePaginate,
-      viewType,
-      setViewType,
     } as Context);
 
   return <Provider value={getContext({ autocomplete: autocompleteState, search: searchState })}>{children}</Provider>;

--- a/packages/hooks/src/ContextProvider/types.ts
+++ b/packages/hooks/src/ContextProvider/types.ts
@@ -6,7 +6,6 @@ export type SearchFn = (query?: string, override?: boolean) => void;
 export type ClearFn = (variables?: { [k: string]: string | undefined }) => void;
 export type ResultClickedFn = (url: string) => void;
 export type PaginateFn = (page: number) => void;
-export type ResultViewType = 'grid' | 'list';
 
 export interface PipelineContextState {
   variables: Variables;
@@ -57,8 +56,6 @@ export interface Context {
   autocomplete: PipelineContextState;
   resultClicked: ResultClickedFn;
   paginate: PaginateFn;
-  setViewType: (v: ResultViewType) => void;
-  viewType: ResultViewType;
 }
 
 type Field = ((data: Record<string, any>) => any) | string | string[] | false;

--- a/packages/hooks/src/useSearchContext/index.ts
+++ b/packages/hooks/src/useSearchContext/index.ts
@@ -8,8 +8,6 @@ import mapToObject from '../utils/mapToObject';
 function useSearchContext() {
   const {
     search: { config, response, search, searching, fields = {} },
-    viewType,
-    setViewType,
   } = useContext();
   const { page, resultsPerPage, totalResults, pageCount, setPage } = usePagination('search');
   const mapResponse = mapToObject(response?.getResponse() as Map<string, any> | undefined);
@@ -30,8 +28,6 @@ function useSearchContext() {
     response: mapResponse,
     searching,
     searched: !isNullOrUndefined(results),
-    viewType,
-    setViewType,
     fields,
     config,
   };

--- a/packages/search-ui/src/ContextProvider/index.tsx
+++ b/packages/search-ui/src/ContextProvider/index.tsx
@@ -1,11 +1,11 @@
 import { SearchProvider } from '@sajari/react-hooks';
 import { createContext, ThemeProvider } from '@sajari/react-sdk-utils';
-import * as React from 'react';
+import React, { useEffect, useState } from 'react';
 import { LiveAnnouncer } from 'react-aria-live';
 import { I18nextProvider } from 'react-i18next';
 
 import i18n from '../i18n';
-import { ContextProviderValues, SearchUIContextProviderValues } from './types';
+import { ContextProviderValues, ResultViewType, SearchUIContextProviderValues } from './types';
 
 const [Provider, useSearchUIContext] = createContext<Required<SearchUIContextProviderValues> & { language?: string }>({
   strict: true,
@@ -25,10 +25,12 @@ const ContextProvider: React.FC<ContextProviderValues> = ({
   importantStyles,
   disableDefaultStyles = false,
   customClassNames = {},
+  viewType: viewTypeProp = 'list',
 }) => {
-  const [language, setLanguage] = React.useState(i18n.language);
+  const [language, setLanguage] = useState(i18n.language);
+  const [viewType, setViewType] = useState<ResultViewType>(viewTypeProp);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const event = 'languageChanged';
     i18n.on(event, setLanguage);
 
@@ -37,8 +39,22 @@ const ContextProvider: React.FC<ContextProviderValues> = ({
     };
   }, []);
 
+  useEffect(() => {
+    setViewType(viewTypeProp);
+  }, [viewTypeProp]);
+
   return (
-    <Provider value={{ disableDefaultStyles, currency, customClassNames, language, ratingMax }}>
+    <Provider
+      value={{
+        disableDefaultStyles,
+        currency,
+        customClassNames,
+        language,
+        ratingMax,
+        viewType,
+        setViewType,
+      }}
+    >
       <SearchProvider
         search={search}
         autocomplete={autocomplete}

--- a/packages/search-ui/src/ContextProvider/types.ts
+++ b/packages/search-ui/src/ContextProvider/types.ts
@@ -9,7 +9,7 @@ export interface SearchUIContextProviderValues {
   /** Currency code to use for any price display */
   currency?: string;
   /** View mode of the results */
-  viewType: ResultViewType;
+  viewType?: ResultViewType;
   setViewType: (type: ResultViewType) => void;
   disableDefaultStyles?: boolean;
   customClassNames?: {

--- a/packages/search-ui/src/ContextProvider/types.ts
+++ b/packages/search-ui/src/ContextProvider/types.ts
@@ -1,11 +1,16 @@
 import { SearchProviderValues } from '@sajari/react-hooks';
 import { ThemeProviderProps } from '@sajari/react-sdk-utils';
 
+export type ResultViewType = 'grid' | 'list';
+
 export interface SearchUIContextProviderValues {
   /** Maximum possible rating value */
   ratingMax?: number;
   /** Currency code to use for any price display */
   currency?: string;
+  /** View mode of the results */
+  viewType: ResultViewType;
+  setViewType: (type: ResultViewType) => void;
   disableDefaultStyles?: boolean;
   customClassNames?: {
     results?: {
@@ -110,4 +115,4 @@ export interface SearchUIContextProviderValues {
 export interface ContextProviderValues
   extends SearchProviderValues,
     ThemeProviderProps,
-    SearchUIContextProviderValues {}
+    Omit<SearchUIContextProviderValues, 'setViewType'> {}

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -12,11 +12,11 @@ import useResultsStyles from './styles';
 import { ResultsProps, ResultValues } from './types';
 
 const Results = (props: ResultsProps) => {
-  const { results: rawResults, setViewType, viewType, searching, fields, error } = useSearchContext();
+  const { results: rawResults, searching, fields, error } = useSearchContext();
   const results = React.useMemo(() => (rawResults ? mapResultFields<ResultValues>(rawResults, fields) : undefined), [
     rawResults,
   ]);
-  const { disableDefaultStyles = false, customClassNames } = useSearchUIContext();
+  const { disableDefaultStyles = false, customClassNames, viewType, setViewType } = useSearchUIContext();
   const { query } = useQuery();
   const { defaultAppearance, appearance = viewType, styles: stylesProp, ...rest } = props;
   const [width, setWidth] = React.useState(0);

--- a/packages/search-ui/src/ViewType/index.tsx
+++ b/packages/search-ui/src/ViewType/index.tsx
@@ -1,6 +1,5 @@
 import { useId } from '@react-aria/utils';
 import { Button, ButtonGroup } from '@sajari/react-components';
-import { useSearchContext } from '@sajari/react-hooks';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,7 +13,7 @@ const ViewType = (props: ViewTypeProps) => {
   const { customClassNames, disableDefaultStyles = false } = useSearchUIContext();
   const { label = t('label'), size, styles: stylesProp, ...rest } = props;
   const id = `view-type-${useId()}`;
-  const { viewType, setViewType } = useSearchContext();
+  const { viewType, setViewType } = useSearchUIContext();
 
   return (
     <ViewOption


### PR DESCRIPTION
Add the option to set a default value for `viewType`. Also, moved viewType state from `hooks` package to `search-ui` package so leaving the hooks to only be in charge of handling data from the backend.