### PR TITLE
docs: fix title issues

### DIFF
--- a/.changeset/lovely-garlics-sort.md
+++ b/.changeset/lovely-garlics-sort.md
@@ -1,0 +1,5 @@
+---
+'sajari-sdk-docs': patch
+---
+
+Fixed title issues

--- a/docs/components/SEO.tsx
+++ b/docs/components/SEO.tsx
@@ -3,10 +3,16 @@ import * as React from 'react';
 
 import defaultSEO from '../seo.config';
 
-function SEO(props: NextSeoProps) {
-  const seo = { ...defaultSEO, ...props };
+interface SeoProps extends NextSeoProps {
+  scope?: string;
+}
 
-  return <NextSeo {...seo} titleTemplate="Sajari React SDK | %s" />;
+function SEO(props: SeoProps) {
+  const { scope, title: titleProp, ...rest } = props;
+  let title = scope ? [titleProp, scope].join(' | ') : titleProp;
+  const seo = { ...defaultSEO, ...rest, title };
+
+  return <NextSeo {...seo} titleTemplate="%s | Sajari React SDK" />;
 }
 
 export default SEO;

--- a/docs/components/SEO.tsx
+++ b/docs/components/SEO.tsx
@@ -9,7 +9,7 @@ interface SeoProps extends NextSeoProps {
 
 function SEO(props: SeoProps) {
   const { scope, title: titleProp, ...rest } = props;
-  let title = scope ? [titleProp, scope].join(' | ') : titleProp;
+  const title = [titleProp, scope].filter(Boolean).join(' | ');
   const seo = { ...defaultSEO, ...rest, title };
 
   return <NextSeo {...seo} titleTemplate="%s | Sajari React SDK" />;

--- a/docs/pages/classes/config.mdx
+++ b/docs/pages/classes/config.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Config"
+  scope="Classes"
   description="The Config type defines mapping between key/value pair param to be sent with each and every request."
 />
 

--- a/docs/pages/classes/fielddictionary.mdx
+++ b/docs/pages/classes/fielddictionary.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="FieldDictionary"
+  scope="Classes"
   description="The FieldDictionary class is used to map fields in your data to the required fields to display in the UI. "
 />
 

--- a/docs/pages/classes/filterbuilder.mdx
+++ b/docs/pages/classes/filterbuilder.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="FilterBuilder"
+  scope="Classes"
   description="The FilterBuilder class is used to construct filters for use with the relevant SearchProvider."
 />
 

--- a/docs/pages/classes/pipeline.mdx
+++ b/docs/pages/classes/pipeline.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Pipeline"
+  scope="Classes"
   description="The Pipeline class is required to configure which pipeline to use for search queries and must be passed to the SearchProvider."
 />
 

--- a/docs/pages/classes/rangefilterbuilder.mdx
+++ b/docs/pages/classes/rangefilterbuilder.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="RangeFilterBuilder"
+  scope="Classes"
   description="The RangeFilterBuilder class is used to construct range filters for use with the relevant SearchProvider."
 />
 

--- a/docs/pages/classes/response.mdx
+++ b/docs/pages/classes/response.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Response"
+  scope="Classes"
   description="The Response class is returned when performing advanced Pipeline methods or handling raw responses."
 />
 

--- a/docs/pages/classes/variables.mdx
+++ b/docs/pages/classes/variables.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Variables"
+  scope="Classes"
   description="The Variables class is a simple key -> value pair object used for every search request. "
 />
 

--- a/docs/pages/components/aspectratio.mdx
+++ b/docs/pages/components/aspectratio.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="AspectRatio"
+  scope="Components"
   description="The AspectRatio component is used to embed responsive videos, maps, images, etc."
 />
 

--- a/docs/pages/components/button.mdx
+++ b/docs/pages/components/button.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Button"
+  scope="Components"
   description="The Button component is used to trigger an action or event, such as submitting a
 form, opening a Dialog, canceling an action, or performing a delete operation."
 />

--- a/docs/pages/components/buttongroup.mdx
+++ b/docs/pages/components/buttongroup.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="ButtonGroup" description="ButtonGroup component is used to group related buttons together." />
+<SEO
+  title="ButtonGroup"
+  scope="Components"
+  description="ButtonGroup component is used to group related buttons together."
+/>
 
 # ButtonGroup
 

--- a/docs/pages/components/checkbox.mdx
+++ b/docs/pages/components/checkbox.mdx
@@ -1,8 +1,8 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Checkbox" description="TBD." />
 <SEO
   title="Checkbox"
+  scope="Components"
   description="The Checkbox component is used in forms when a user needs to select multiple values
 from several options."
 />

--- a/docs/pages/components/combobox.mdx
+++ b/docs/pages/components/combobox.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Combobox"
+  scope="Components"
   description="The Combobox component is used to capture query input via a text field. It can also provide suggestions, typeahead and instant search modes."
 />
 

--- a/docs/pages/components/heading.mdx
+++ b/docs/pages/components/heading.mdx
@@ -1,6 +1,6 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Heading" description="The Heading component is used for rendering headlines." />
+<SEO title="Heading" scope="Components" description="The Heading component is used for rendering headlines." />
 
 # Heading
 

--- a/docs/pages/components/image.mdx
+++ b/docs/pages/components/image.mdx
@@ -1,8 +1,14 @@
 import SEO from '../../components/SEO';
 
+<SEO
+  title="Image"
+  scope="Components"
+  description="The Image component is used to display images with added options for cropping."
+/>
+
 # Image
 
-The `Image` component is used to display images.
+The `Image` component is used to display images with added options for cropping.
 
 ## Import
 

--- a/docs/pages/components/index.mdx
+++ b/docs/pages/components/index.mdx
@@ -1,6 +1,9 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Components" description="TBD" />
+<SEO
+  title="Components"
+  description="Core components that allow you to build a beautiful search interface with any back end."
+/>
 
 # Components
 

--- a/docs/pages/components/modal.mdx
+++ b/docs/pages/components/modal.mdx
@@ -2,8 +2,8 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Modal"
-  description="A dialog is a window overlaid on either the primary window or another dialog
-window."
+  scope="Components"
+  description="A dialog is a window overlaid on either the primary window or another dialog window."
 />
 
 # Modal (Dialog)

--- a/docs/pages/components/pagination.mdx
+++ b/docs/pages/components/pagination.mdx
@@ -1,7 +1,10 @@
 import SEO from '../../components/SEO';
-import { Button } from '@sajari/react-components';
 
-<SEO title="Pagination" description="Pagination component is used for paging through paged result sets." />
+<SEO
+  title="Pagination"
+  scope="Components"
+  description="Pagination component is used for paging through paged result sets."
+/>
 
 # Pagination
 

--- a/docs/pages/components/poweredby.mdx
+++ b/docs/pages/components/poweredby.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="PoweredBy"
+  scope="Components"
   description="The PoweredBy component is used to display that you're awesome and Sajari powering your search UI 💪"
 />
 

--- a/docs/pages/components/radio.mdx
+++ b/docs/pages/components/radio.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Radio" description="Radio buttons are used when only one choice may be selected in a series of options." />
+<SEO
+  title="Radio"
+  scope="Components"
+  description="Radio buttons are used when only one choice may be selected in a series of options."
+/>
 
 # Radio
 

--- a/docs/pages/components/rangeinput.mdx
+++ b/docs/pages/components/rangeinput.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="RangeInput"
+  scope="Components"
   description="The RangeInput component allows users to be able to search through items that within min and max value."
 />
 

--- a/docs/pages/components/rating.mdx
+++ b/docs/pages/components/rating.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Rating" description="The Rating component is used to display ratings using stars or custom indicators. " />
+<SEO
+  title="Rating"
+  scope="Components"
+  description="The Rating component is used to display ratings using stars or custom indicators. "
+/>
 
 # Rating
 

--- a/docs/pages/components/resizeobserver.mdx
+++ b/docs/pages/components/resizeobserver.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="ResizeObserver"
+  scope="Components"
   description="The ResizeObserver component is used for listening to resize events on a container."
 />
 

--- a/docs/pages/components/select.mdx
+++ b/docs/pages/components/select.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Select"
+  scope="Components"
   description="The Select component allows users pick a value from predefined options. Ideally, it should be used when there are more than 5 options, otherwise you might consider using a radio group instead."
 />
 

--- a/docs/pages/components/swatch.mdx
+++ b/docs/pages/components/swatch.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Swatch"
+  scope="Components"
   description="The Swatch component acts like a color filter that allows for more granular product/item searching."
 />
 

--- a/docs/pages/components/tabs.mdx
+++ b/docs/pages/components/tabs.mdx
@@ -1,6 +1,6 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Tabs" description="An accessible Tabs component for your application" />
+<SEO title="Tabs" scope="Components" description="An accessible Tabs component for your application." />
 
 # Tabs
 

--- a/docs/pages/components/text.mdx
+++ b/docs/pages/components/text.mdx
@@ -1,5 +1,7 @@
 import SEO from '../../components/SEO';
 
+<SEO title="Text" scope="Components" description="The Text component is used for rendering text elements." />
+
 # Text
 
 The `Text` component is used to display text.

--- a/docs/pages/hooks/index.mdx
+++ b/docs/pages/hooks/index.mdx
@@ -1,6 +1,6 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Hooks" description="TBD" />
+<SEO title="Hooks" description="Hooks that allow you to build a search interface using any component library." />
 
 # Hooks
 

--- a/docs/pages/hooks/searchprovider.mdx
+++ b/docs/pages/hooks/searchprovider.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="SearchProvider" description="The SearchProvider component..." />
+<SEO
+  title="SearchProvider"
+  scope="Hooks"
+  description="The SearchProvider should be used as a wrapper for the entire application to provide a way to share application state between hooks, for example, the current query, active filters or the search response."
+/>
 
 # SearchProvider
 

--- a/docs/pages/hooks/useautocomplete.mdx
+++ b/docs/pages/hooks/useautocomplete.mdx
@@ -2,7 +2,11 @@ import SEO from '../../components/SEO';
 import { useState } from 'react';
 import { Select } from '@sajari/react-components';
 
-<SEO title="useAutocomplete" description="useAutocomplete provides result and method for the autocomplete pipeline." />
+<SEO
+  title="useAutocomplete"
+  scope="Hooks"
+  description="useAutocomplete provides result and method for the autocomplete pipeline."
+/>
 
 # useAutocomplete
 

--- a/docs/pages/hooks/usefilter.mdx
+++ b/docs/pages/hooks/usefilter.mdx
@@ -1,6 +1,6 @@
 import SEO from '../../components/SEO';
 
-<SEO title="useFilter" description="useFilter returns the filter items (current values and options)" />
+<SEO title="useFilter" scope="Hooks" description="useFilter returns the filter items (current values and options)" />
 
 # useFilter
 

--- a/docs/pages/hooks/usepagination.mdx
+++ b/docs/pages/hooks/usepagination.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="usePagination"
+  scope="Hooks"
   description="usePagination provides conveniences that allow user to integrate the Pagination component with the search context on the fly."
 />
 

--- a/docs/pages/hooks/usequery.mdx
+++ b/docs/pages/hooks/usequery.mdx
@@ -1,6 +1,6 @@
 import SEO from '../../components/SEO';
 
-<SEO title="useQuery" description="useQuery provides a getter & setter for the current query." />
+<SEO title="useQuery" scope="Hooks" description="useQuery provides a getter and setter for the current query." />
 
 # useQuery
 

--- a/docs/pages/hooks/userangefilter.mdx
+++ b/docs/pages/hooks/userangefilter.mdx
@@ -2,7 +2,8 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="useRangeFilter"
-  description="useRangeFilter returns the filter range (current range and the range for min and max)"
+  scope="Hooks"
+  description="useRangeFilter returns the filter range (current range and the range for min and max)."
 />
 
 # useRangeFilter

--- a/docs/pages/hooks/useresultsperpage.mdx
+++ b/docs/pages/hooks/useresultsperpage.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="useResultsPerPage" description="useResultsPerPage provides getter/setter for the resultsPerPage param." />
+<SEO
+  title="useResultsPerPage"
+  scope="Hooks"
+  description="useResultsPerPage provides getter/setter for the resultsPerPage param."
+/>
 
 # useResultsPerPage
 

--- a/docs/pages/hooks/usesearch.mdx
+++ b/docs/pages/hooks/usesearch.mdx
@@ -1,10 +1,14 @@
 import SEO from '../../components/SEO';
 
-<SEO title="useSearch" description="useSearch provides a getter & setter for the current query." />
+<SEO
+  title="useSearch"
+  scope="Hooks"
+  description="useSearch provides a way to perform a search using the current context or a custom one-off search."
+/>
 
 # useSearch
 
-`useSearch` provides a way to perform a search.
+`useSearch` provides a way to perform a search using the current context or a custom one-off search.
 
 ```js
 import { useSearch } from '@sajari/react-hooks';

--- a/docs/pages/hooks/usesearchcontext.mdx
+++ b/docs/pages/hooks/usesearchcontext.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="useSearchContext" description="useSearchContext will return the data from the current search." />
+<SEO
+  title="useSearchContext"
+  scope="Hooks"
+  description="useSearchContext will return the data from the current search request."
+/>
 
 # useSearchContext
 

--- a/docs/pages/hooks/usesorting.mdx
+++ b/docs/pages/hooks/usesorting.mdx
@@ -1,6 +1,6 @@
 import SEO from '../../components/SEO';
 
-<SEO title="useSorting" description="useSorting provides getter/setter for sorting results." />
+<SEO title="useSorting" scope="Hooks" description="useSorting provides a getter and setter for sorting results." />
 
 # useSorting
 

--- a/docs/pages/hooks/usetracking.mdx
+++ b/docs/pages/hooks/usetracking.mdx
@@ -1,6 +1,6 @@
 import SEO from '../../components/SEO';
 
-<SEO title="useTracking" description="useTracking provides methods for enabling tracking features." />
+<SEO title="useTracking" scope="Hooks" description="useTracking provides methods for enabling tracking features." />
 
 # useTracking
 

--- a/docs/pages/hooks/usevariables.mdx
+++ b/docs/pages/hooks/usevariables.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="useVariables"
+  scope="Hooks"
   description="useVariables provide a way for user to modify the Variables instance directly."
 />
 

--- a/docs/pages/search-ui/filter.mdx
+++ b/docs/pages/search-ui/filter.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Filter"
+  scope="Search UI"
   description="Filter component is used to render filter options allowing refining of search results. "
 />
 

--- a/docs/pages/search-ui/input.mdx
+++ b/docs/pages/search-ui/input.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Input"
+  scope="Search UI"
   description="Input component is a component that is used to get user input in a text field. It can also provide suggestions, typeahead and instant search modes."
 />
 

--- a/docs/pages/search-ui/pagination.mdx
+++ b/docs/pages/search-ui/pagination.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Pagination" description="The Pagination`component is used for paging through paged result sets." />
+<SEO
+  title="Pagination"
+  scope="Search UI"
+  description="The Pagination`component is used for paging through paged result sets."
+/>
 
 # Pagination
 

--- a/docs/pages/search-ui/results.mdx
+++ b/docs/pages/search-ui/results.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Results" description="The Results component is used to display results response from a search query." />
+<SEO
+  title="Results"
+  scope="Search UI"
+  description="The Results component is used to display results response from a search query."
+/>
 
 # Results
 

--- a/docs/pages/search-ui/resultsperpage.mdx
+++ b/docs/pages/search-ui/resultsperpage.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="ResultsPerPage"
+  scope="Search UI"
   description="The ResultsPerPage component is used to capture user input for how many results displayed per page."
 />
 

--- a/docs/pages/search-ui/searchprovider.mdx
+++ b/docs/pages/search-ui/searchprovider.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="SearchProvider" description="The SearchProvider component..." />
+<SEO
+  title="SearchProvider"
+  scope="Search UI"
+  description="The SearchProvider should be used as a wrapper for the entire application to provide a way to share application state between components, for example, the current query, active filters or the search response."
+/>
 
 # SearchProvider
 

--- a/docs/pages/search-ui/sorting.mdx
+++ b/docs/pages/search-ui/sorting.mdx
@@ -1,6 +1,10 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Sorting" description="The Sorting component is used to capture user input on how to sort search results." />
+<SEO
+  title="Sorting"
+  scope="Search UI"
+  description="The Sorting component is used to capture user input on how to sort search results."
+/>
 
 # Sorting
 

--- a/docs/pages/search-ui/summary.mdx
+++ b/docs/pages/search-ui/summary.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Summary"
+  scope="Search UI"
   description="Summary is a component used to display display the number of results and the latency from a search query."
 />
 

--- a/docs/pages/search-ui/viewtype.mdx
+++ b/docs/pages/search-ui/viewtype.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="ViewType"
+  scope="Search UI"
   description="The ViewType component is used to allow toggling between viewing modes of results."
 />
 

--- a/docs/pages/tracking/clicktracking.mdx
+++ b/docs/pages/tracking/clicktracking.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="Click Tracking"
+  scope="Tracking"
   description="Click tracking refers to recording user click interactions alongside search results. This is usually the successful search outcome customers use to power machine learning."
 />
 

--- a/docs/pages/tracking/index.mdx
+++ b/docs/pages/tracking/index.mdx
@@ -1,10 +1,13 @@
 import SEO from '../../components/SEO';
 
-<SEO title="Tracking" description="TBD" />
+<SEO
+  title="Tracking"
+  description="Analytics in Sajari can give you insights into the search behavior of your users and how your content is performing."
+/>
 
 # Tracking
 
-Analytics in Sajari can give you insights into the search behavior of your users and how your content is performing.
+Tracking in Sajari can give you insights into the search behavior of your users and how your content is performing.
 
 ## 1. Getting Started
 

--- a/docs/pages/tracking/posnegtracking.mdx
+++ b/docs/pages/tracking/posnegtracking.mdx
@@ -2,6 +2,7 @@ import SEO from '../../components/SEO';
 
 <SEO
   title="PosNeg Tracking"
+  scope="Tracking"
   description="PosNeg tracking refers to the recording of variably weighted user interactions with search results."
 />
 

--- a/docs/seo.config.ts
+++ b/docs/seo.config.ts
@@ -1,10 +1,6 @@
 const SEO = {
   title: 'Sajari React SDK',
   description: 'Build a beautiful and accessible search interface using our powerful React SDK.',
-  openGraph: {
-    url: 'https://react.sajari.com',
-    title: 'Sajari React SDK',
-  },
 };
 
 export default SEO;


### PR DESCRIPTION
Rejigged the order so that `Sajari React SDK` is last given it has the least important. 

The order is now: `{Object} | {Scope} | Sajari React SDK`

For example: `useSearch | Hooks | Sajari React SDK`. 