### PR TITLE
fix: support unprefixed SpeechRecognition

### DIFF
--- a/.changeset/breezy-ties-argue.md
+++ b/.changeset/breezy-ties-argue.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+---
+
+Add support for SpeechRecognition (unprefixed)

--- a/packages/components/src/hooks/useVoiceInput.ts
+++ b/packages/components/src/hooks/useVoiceInput.ts
@@ -67,7 +67,7 @@ export default function useVoiceInput(onResult?: (r: string) => void) {
   }, [active, supported, onResult]);
 
   return {
-    supported,
+    supported: supported !== false,
     result,
     active,
     start,

--- a/packages/components/src/hooks/useVoiceInput.ts
+++ b/packages/components/src/hooks/useVoiceInput.ts
@@ -2,20 +2,34 @@
 import { isSSR } from '@sajari/react-sdk-utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+type SpeechRecognitionSupport = 'native' | 'webkit' | false;
+
 export default function useVoiceInput(onResult?: (r: string) => void) {
-  const [supported, setSupported] = useState(false);
+  const [supported, setSupported] = useState<SpeechRecognitionSupport>(false);
   const [active, setActive] = useState(false);
   const [result, setResult] = useState('');
   const recognitionRef = useRef<SpeechRecognition>();
 
   useEffect(() => {
-    setSupported(!isSSR() && window.hasOwnProperty('webkitSpeechRecognition'));
+    if (isSSR()) {
+      return;
+    }
+
+    if (window.hasOwnProperty('SpeechRecognition')) {
+      setSupported('native');
+    } else if (window.hasOwnProperty('webkitSpeechRecognition')) {
+      setSupported('webkit');
+    }
   }, []);
 
   useEffect(() => {
     if (supported) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      recognitionRef.current = new (window as any).webkitSpeechRecognition() as SpeechRecognition;
+      if (supported === 'native') {
+        recognitionRef.current = new window.SpeechRecognition();
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        recognitionRef.current = new (window as any).webkitSpeechRecognition() as SpeechRecognition;
+      }
     }
   }, [supported]);
 


### PR DESCRIPTION
Currently, we only support the prefixed `webkitSpeechRecognition`. This change adds support for the unprefixed version. Apparently, support is coming in the new version of Safari. 

https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition