### PR TITLE
utils: add MergeOptions for merge util

### DIFF
--- a/.changeset/curvy-cows-retire.md
+++ b/.changeset/curvy-cows-retire.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-sdk-utils': patch
+---
+
+Added MergeOptions for the merge util

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -18,16 +18,15 @@ interface MergeObject {
   [k: string]: any;
 }
 
-/**
- * How arrays should be merged
- * 'concat' Concatenate arrays.
- * 'union' Union arrays, skipping items that already exist.
- * 'replace' Replace all array items.
- */
 type MergeArrayHandling = 'concat' | 'union' | 'replace';
 
 export class MergeOptions {
-  /** Whether to concatinate arrays */
+  /**
+   * How arrays should be merged
+   * 'concat' - Concatenate arrays.
+   * 'union' - Union arrays, skipping items that already exist.
+   * 'replace' - Replace all array items.
+   */
   public arrayHandling: MergeArrayHandling;
 
   constructor(options?: MergeOptions) {

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -18,12 +18,41 @@ interface MergeObject {
   [k: string]: any;
 }
 
+/**
+ * How arrays should be merged
+ * 'concat' Concatenate arrays.
+ * 'union' Union arrays, skipping items that already exist.
+ * 'replace' Replace all array items.
+ */
+type MergeArrayHandling = 'concat' | 'union' | 'replace';
+
+export class MergeOptions {
+  /** Whether to concatinate arrays */
+  public arrayHandling: MergeArrayHandling;
+
+  constructor(options?: MergeOptions) {
+    this.arrayHandling = options?.arrayHandling ?? 'concat';
+  }
+}
+
 // Deep extend destination object with N more objects
-export function merge(target: MergeObject, ...sources: MergeObject[]): MergeObject {
+export function merge(
+  options: MergeOptions | MergeObject,
+  target: MergeObject,
+  ...sources: MergeObject[]
+): MergeObject {
+  // If options aren't passed
+  if (!(options instanceof MergeOptions)) {
+    target = options;
+    sources = [target, ...sources];
+    options = new MergeOptions();
+  }
+
   if (!isObject(target) || !sources.length) {
     return target;
   }
 
+  const { arrayHandling } = options as MergeOptions;
   const source = sources.shift();
 
   if (!source || !isObject(source)) {
@@ -35,9 +64,24 @@ export function merge(target: MergeObject, ...sources: MergeObject[]): MergeObje
     const sourceValue = source[key];
 
     if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
-      target[key] = targetValue.concat(sourceValue);
+      switch (arrayHandling) {
+        case 'concat':
+          target[key] = targetValue.concat(sourceValue);
+          break;
+
+        case 'replace':
+          target[key] = sourceValue;
+          break;
+
+        case 'union':
+          target[key] = Array.from(new Set([...targetValue, ...sourceValue]));
+          break;
+
+        default:
+          break;
+      }
     } else if (isObject(targetValue) && isObject(sourceValue)) {
-      target[key] = merge({ ...targetValue }, sourceValue);
+      target[key] = merge(options, { ...targetValue }, sourceValue);
     } else {
       target[key] = sourceValue;
     }

--- a/packages/utils/src/test/object.test.ts
+++ b/packages/utils/src/test/object.test.ts
@@ -1,8 +1,9 @@
-import { filterObject, merge } from '../object';
+import { filterObject, merge, MergeOptions } from '../object';
 
 test.each([
-  [{ a: 2 }, { a: 1 }, { a: 1 }],
+  [new MergeOptions(), { a: 2 }, { a: 1 }, { a: 1 }],
   [
+    new MergeOptions(),
     {
       foo: 0,
       baz: 2,
@@ -15,11 +16,13 @@ test.each([
     },
   ],
   [
+    new MergeOptions(),
     { color: { primary: '#ffffff', secondary: '#000000' } },
     { color: { primary: '#333333' } },
     { color: { primary: '#333333', secondary: '#000000' } },
   ],
   [
+    new MergeOptions(),
     {
       main: {
         header: {
@@ -44,8 +47,38 @@ test.each([
       },
     },
   ],
-])('merge(%o, %o)', (target, source, expected) => {
-  expect(merge(target, source)).toEqual(expected);
+  [
+    new MergeOptions({ arrayHandling: 'concat' }),
+    {
+      a: [1, 2, 3],
+    },
+    { a: [3, 4, 5, 6] },
+    {
+      a: [1, 2, 3, 3, 4, 5, 6],
+    },
+  ],
+  [
+    new MergeOptions({ arrayHandling: 'union' }),
+    {
+      a: [1, 2, 3],
+    },
+    { a: [3, 4, 5, 6] },
+    {
+      a: [1, 2, 3, 4, 5, 6],
+    },
+  ],
+  [
+    new MergeOptions({ arrayHandling: 'replace' }),
+    {
+      a: [1, 2, 3],
+    },
+    { a: [3, 4, 5, 6] },
+    {
+      a: [3, 4, 5, 6],
+    },
+  ],
+])('merge(%o, %o)', (options, target, source, expected) => {
+  expect(merge(options, target, source)).toEqual(expected);
 });
 
 test.each([


### PR DESCRIPTION
This change adds the ability to specify how arrays are merged. Currently, the options are:

 * `'concat'` - Concatenate arrays.
 * `'union'` - Union arrays, skipping items that already exist.
 * `'replace'` - Replace all array items.