### PR TITLE
fix: make clear method public in useSearchContext

### DIFF
--- a/.changeset/sweet-ants-roll.md
+++ b/.changeset/sweet-ants-roll.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-hooks': patch
+---
+
+Made clear method public in useSearchContext so that it can be used to reset the response.

--- a/packages/hooks/src/useSearchContext/index.ts
+++ b/packages/hooks/src/useSearchContext/index.ts
@@ -7,7 +7,7 @@ import { mapToObject } from '../utils';
 
 function useSearchContext() {
   const {
-    search: { config, response, search, searching, fields = {} },
+    search: { config, response, search, searching, fields = {}, clear },
   } = useContext();
   const { page, resultsPerPage, totalResults, pageCount, setPage } = usePagination('search');
   const mapResponse = mapToObject(response?.getResponse() as Map<string, any> | undefined);
@@ -30,6 +30,7 @@ function useSearchContext() {
     searched: !isNullOrUndefined(results),
     fields,
     config,
+    clear,
   };
 }
 


### PR DESCRIPTION
export `clear` method in the return of useSearchContext so that it can be used to reset the response.