### PR TITLE
fix: typing mid query snaps to the end of the query

### DIFF
--- a/.changeset/tidy-clouds-press.md
+++ b/.changeset/tidy-clouds-press.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fixed cursor jumps to end of input when typing mid query.

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -319,6 +319,9 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
                   onChange(e.target.value);
                   setTypedInputValue(e.target.value);
                 },
+                onChange: (e: ChangeEvent<HTMLInputElement>) => {
+                  setValue(e.target.value);
+                },
               }),
               focusProps,
             )}


### PR DESCRIPTION
Fix the issue raised internally by the team [here](https://sajari.atlassian.net/browse/SF-250). A similar issue was raised and fixed in https://github.com/downshift-js/downshift/issues/1108.