### PR TITLE
fix: resetting range filter ignores other filters

### DIFF
--- a/.changeset/polite-cups-remember.md
+++ b/.changeset/polite-cups-remember.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+Fixed the issue of incorrect response after using filters. It was caused by the `filter()` method of a count aggregate filter will ignore the value that is not in the options.

--- a/packages/hooks/src/ContextProvider/controllers/filters/FilterBuilder.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/FilterBuilder.ts
@@ -181,13 +181,6 @@ export default class FilterBuilder {
    * Builds up the filter string from the current filter and it's children.
    */
   public filter() {
-    // Initial build up the filter value for a count filter field, where the options is not yet came from the response
-    if (isEmpty(this.options) && this.count) {
-      return this.current
-        .map((label) => `(${this.array ? `${this.field} ~ ["${label}"]` : `${this.field} = "${label}"`})`)
-        .join(` ${this.joinOperator} `);
-    }
-
     const options = this.current
       .map((c) => {
         let f = this.options[c];
@@ -196,6 +189,9 @@ export default class FilterBuilder {
         }
         if (!isEmpty(f)) {
           f = escapeValue(f);
+        }
+        if (this.count && f === undefined && c) {
+          f = this.array ? `${this.field} ~ ["${c}"]` : `${this.field} = "${c}"`;
         }
         return f;
       })

--- a/packages/hooks/src/ContextProvider/controllers/filters/test/FilterBuilder.test.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/test/FilterBuilder.test.ts
@@ -99,4 +99,15 @@ describe('FilterBuilder', () => {
     });
     expect(filter.filter()).toBe('(category ~ ["apple"]) OR (category ~ ["samsung"])');
   });
+
+  it('if count is not set, ignore any selected values which are not in the options', () => {
+    const filter = new FilterBuilder({
+      name: 'category',
+      field: 'category',
+      options: { dell: 'category = "dell"' },
+      count: false,
+      initial: ['apple', 'dell', 'samsung'],
+    });
+    expect(filter.filter()).toBe('category = "dell"');
+  });
 });

--- a/packages/hooks/src/ContextProvider/controllers/filters/utils.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/utils.ts
@@ -6,7 +6,15 @@ import RangeFilterBuilder from './RangeFilterBuilder';
 type Type = 'filter' | 'countFilters';
 
 // Group expressions into an ARRAY_MATCH
-const buildArrayMatch = (expressions: Array<string>) => `ARRAY_MATCH(${expressions.filter(Boolean).join(' AND ')})`;
+const buildArrayMatch = (expressions: Array<string>) => {
+  let list = expressions.filter(Boolean);
+
+  if (list.length > 1) {
+    list = list.map((expression) => `(${expression})`);
+  }
+
+  return `ARRAY_MATCH(${list.join(' AND ')})`;
+};
 
 // Group filters together using ARRAY_MATCH
 export function groupFilters(


### PR DESCRIPTION
**WHAT**:
If you set a price filter along with another filter (e.g. `product_type`) in the Shopify UI to a range where it returns no results, then you reset the price range, it returns all results rather than just the results for the other filter.

**WHY**:
Take the possible scenario:
- Step 1: search query "hello" with a range filter of field `price` and list filter of field `category`. This will respond 999 items and aggregate options for `category` is `[A, B, C]`.
- Step 2: select the option `A` will respond 100 items.
- Step 3: select the range `[x, y]` for the `price` will respond 9 items and the new aggregate options is `[B]`.
- Step 4: reset the price range will respond 999 items instead of 100.

It's because the current implementation of `filter()` method will ignore the value which is not in the options. So in step 3, the selected value is `A` but the options is `[B]` so after the reset button of the price filter is clicked, the `filter()` will return `""` instead of `category = "A"`.

**HOW**:
For an aggregate filter, compute the filter expression even if a value is not in the option list.


