### PR TITLE
fix: tab sometimes unclickable

### DIFF
--- a/.changeset/violet-ways-knock.md
+++ b/.changeset/violet-ways-knock.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+---
+
+Fixed tabs are unclickable because the ref DOM node from `cloneElement` sometimes gets `null`.

--- a/packages/components/src/Tabs/TabList/index.tsx
+++ b/packages/components/src/Tabs/TabList/index.tsx
@@ -19,7 +19,7 @@ const TabList = React.forwardRef((props: TabListProps, ref?: React.Ref<HTMLDivEl
     disableDefaultStyles = false,
   } = useTabContext();
   const styles = getStylesObject(useTabListStyles(), disableDefaultStyles);
-  const allNodes = useRef<HTMLElement[]>([]);
+  const allNodes = useRef<(HTMLElement | null)[]>([]);
   const validChildren = cleanChildren(children);
 
   const focusableIndexes = validChildren
@@ -32,7 +32,7 @@ const TabList = React.forwardRef((props: TabListProps, ref?: React.Ref<HTMLDivEl
   const updateIndex = (index: number) => {
     const childIndex = focusableIndexes[index];
 
-    allNodes.current[childIndex].focus();
+    allNodes.current[childIndex]?.focus();
 
     if (onChangeTab) {
       onChangeTab(childIndex);
@@ -81,7 +81,7 @@ const TabList = React.forwardRef((props: TabListProps, ref?: React.Ref<HTMLDivEl
     const handleClick = (event: React.MouseEvent) => {
       // Hack for Safari. Buttons don't receive focus on click on Safari
       // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-      allNodes.current[index].focus();
+      allNodes.current[index]?.focus();
 
       onManualTabChange(index);
       onChangeTab(index);
@@ -92,7 +92,7 @@ const TabList = React.forwardRef((props: TabListProps, ref?: React.Ref<HTMLDivEl
     };
 
     return cloneElement(child, {
-      ref: (node: HTMLElement) => {
+      ref: (node: HTMLElement | null) => {
         allNodes.current[index] = node;
         return node;
       },


### PR DESCRIPTION
**WHAT**:
Sometimes, clicking on a tab shows no response. See the video for details:

https://user-images.githubusercontent.com/12707960/108721944-25b1a080-7555-11eb-867a-c3eeef1235a5.mov

**WHY**:
The node param from ref callback sometimes gets `null` (not yet found out why) so calling `.focus` on a `null` object will cause the error and block the UI.
```jsx
    return cloneElement(child, {
      ref: (node: HTMLElement) => {
        allNodes.current[index] = node;
        return node;
      },
```
**HOW**:
Prevent the issue by checking `null` before calling `.focus`. Note that, it is a workaround solution because the focus function could be broken instead.