### PR TITLE
fix: add relative position for input container

### DIFF
--- a/.changeset/five-coins-bow.md
+++ b/.changeset/five-coins-bow.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Add relative position to input in attach mode

--- a/.changeset/warm-scissors-wash.md
+++ b/.changeset/warm-scissors-wash.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-components': patch
+---
+
+Add relative position to input in attach mode

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -317,7 +317,16 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
         ...inputProps,
         ...Array.from(input.attributes).reduce((acc, attr) => ({ ...acc, [attr.nodeName]: attr.nodeValue }), {}),
       });
-      const ContainerComponent = React.createElement('div', getComboboxProps(), [InputComponent, <Dropdown />]);
+      const ContainerComponent = React.createElement(
+        'div',
+        {
+          ...getComboboxProps(),
+          style: {
+            position: 'relative',
+          },
+        },
+        [InputComponent, <Dropdown />],
+      );
       input.remove();
       return ReactDOM.createPortal(ContainerComponent, container as Element);
     }


### PR DESCRIPTION
@sampotts Sorry I think the relative positioning should have been here instead of in the widgets.