### PR TITLE
fix: sort rating options from highest to lowest

### DIFF
--- a/.changeset/calm-laws-hammer.md
+++ b/.changeset/calm-laws-hammer.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': patch
+'sajari-sdk-docs': patch
+---
+
+Allow ratings filter options to be ordered highest to lowest.

--- a/packages/search-ui/src/Filter/RatingFilter.tsx
+++ b/packages/search-ui/src/Filter/RatingFilter.tsx
@@ -22,7 +22,16 @@ const RatingFilter = ({ name, title }: Omit<RatingFilterProps, 'type'>) => {
     [ratingMax, JSON.stringify(customClassNames.filter?.rating), disableDefaultStyles],
   );
 
-  return <ListFilter name={name} title={title} sort="none" pinSelected={false} itemRender={renderRating} />;
+  return (
+    <ListFilter
+      name={name}
+      title={title}
+      sort="alpha"
+      sortAscending={false}
+      pinSelected={false}
+      itemRender={renderRating}
+    />
+  );
 };
 
 export default RatingFilter;


### PR DESCRIPTION
At the moment the ratings filter component options can only be ordered from 1 star to 5 stars but it makes more sense to order it from 5 stars to 1 star like Amazon do.

**Before**:

![image](https://user-images.githubusercontent.com/12707960/111491365-607eb100-876e-11eb-83f6-2ea89528dbb0.png)

**After**:

![image](https://user-images.githubusercontent.com/12707960/111491423-6ecccd00-876e-11eb-8878-cc3600107e72.png)

This resolved the [internal issue](https://sajari.atlassian.net/browse/SF-296).