### PR TITLE
fix: voice input not trigger search

### DIFF
--- a/.changeset/five-waves-press.md
+++ b/.changeset/five-waves-press.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+'sajari-sdk-docs': patch
+---
+
+Fixed the issue when using speech search does not trigger a search for the voice input. Also make an update to open the dropdown menu if the input mode is `suggestions`.

--- a/.changeset/five-waves-press.md
+++ b/.changeset/five-waves-press.md
@@ -4,4 +4,4 @@
 'sajari-sdk-docs': patch
 ---
 
-Fixed the issue when using speech search does not trigger a search for the voice input. Also make an update to open the dropdown menu if the input mode is `suggestions`.
+Fixed the issue when using speech search does not trigger a search for the voice input. Also make an update to open the dropdown menu if the input mode is `results`.

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -80,6 +80,7 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     inputValue,
     setInputValue,
     closeMenu,
+    openMenu,
   } = useCombobox<T>({
     items,
     itemToString,
@@ -237,6 +238,9 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     if (captureVoiceInput) {
       setInputValue(input);
       setTypedInputValue(input);
+      if (mode === 'results') {
+        openMenu();
+      }
     }
     onVoiceInput(input);
   };

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -63,6 +63,16 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.Ref<HTMLInput
     [onChange, mode, search],
   );
 
+  const onVoiceInput = useCallback(
+    (value) => {
+      if (onChange) {
+        onChange(value);
+      }
+      search(value);
+    },
+    [search, onChange],
+  );
+
   const onKeyDownMemoized = useCallback(
     (e) => {
       if (e.key === 'Enter' && (mode === 'typeahead' || mode === 'suggestions' || mode === 'standard')) {
@@ -90,6 +100,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.Ref<HTMLInput
       ref={ref}
       placeholder={placeholder}
       mode={mode as Exclude<InputProps<any>['mode'], 'instant'>}
+      onVoiceInput={onVoiceInput}
       items={items}
       completion={mode === 'typeahead' ? completion : ''}
       value={query}

--- a/packages/search-ui/src/Input/types.ts
+++ b/packages/search-ui/src/Input/types.ts
@@ -1,7 +1,7 @@
 import { ComboboxProps } from '@sajari/react-components';
 
 export interface InputProps<T>
-  extends Pick<ComboboxProps<T>, 'placeholder' | 'onSelect' | 'onChange' | 'inputElement'> {
+  extends Pick<ComboboxProps<T>, 'placeholder' | 'onSelect' | 'onChange' | 'inputElement' | 'enableVoice'> {
   mode?: ComboboxProps<T>['mode'] | 'instant';
   /* Sets how many autocomplete suggestions are shown in the box below the search input */
   maxSuggestions?: number;


### PR DESCRIPTION
Fix the issue when using speech search does not trigger a search for the voice input. Also, make an update to open the dropdown menu if the input mode is `results`.

**Standard mode**

https://user-images.githubusercontent.com/12707960/112083180-29b6f980-8bb9-11eb-948a-367808266a11.mov

**Results mode**

https://user-images.githubusercontent.com/12707960/112082668-56b6dc80-8bb8-11eb-98ca-4227b5e39abd.mov




