### PR TITLE
fix: className of Input being overridden by context customClassNames

### DIFF
--- a/.changeset/five-hats-sparkle.md
+++ b/.changeset/five-hats-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': patch
+'sajari-sdk-docs': patch
+---
+
+Fixed the issue when passing `className` for `Input` does not have effect if the `customClassNames` is set in the context.

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -2,6 +2,7 @@
 import { Combobox } from '@sajari/react-components';
 import { useAutocomplete, useQuery, useSearchContext } from '@sajari/react-hooks';
 import { __DEV__, isArray } from '@sajari/react-sdk-utils';
+import classnames from 'classnames';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -19,6 +20,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.Ref<HTMLInput
     onSelect,
     onChange,
     maxSuggestions = mode === 'results' ? 5 : 10,
+    className,
     ...rest
   } = props;
   const { results: rawResults, search, searching, fields } = useSearchContext();
@@ -108,7 +110,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.Ref<HTMLInput
       onChange={onChangeMemoized}
       onKeyDown={onKeyDownMemoized}
       onSelect={onSelectMemoized}
-      className={customClassNames.input?.container}
+      className={classnames(customClassNames.input?.container, className)}
       dropdownClassName={customClassNames.input?.dropdown}
       dropdownFooterClassName={customClassNames.input?.dropdownFooter}
       dropdownHighlightItemClassName={customClassNames.input?.dropdownHighlightItem}

--- a/packages/search-ui/src/Input/types.ts
+++ b/packages/search-ui/src/Input/types.ts
@@ -1,7 +1,10 @@
 import { ComboboxProps } from '@sajari/react-components';
 
 export interface InputProps<T>
-  extends Pick<ComboboxProps<T>, 'placeholder' | 'onSelect' | 'onChange' | 'inputElement' | 'enableVoice'> {
+  extends Pick<
+    ComboboxProps<T>,
+    'placeholder' | 'onSelect' | 'onChange' | 'inputElement' | 'enableVoice' | 'className'
+  > {
   mode?: ComboboxProps<T>['mode'] | 'instant';
   /* Sets how many autocomplete suggestions are shown in the box below the search input */
   maxSuggestions?: number;


### PR DESCRIPTION
Fix the issue when passing `className` for `Input` does not work if the `customClassNames` is set in the context.