### PR TITLE
fix: modal being overlapped by elements having higher z-index

### DIFF
--- a/.changeset/moody-colts-happen.md
+++ b/.changeset/moody-colts-happen.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-sdk-utils': patch
+'@sajari/react-search-ui': patch
+---
+
+Increase the `z-index` value of `Modal` to 10000 to somewhat avoid it being overlapped by other elements.

--- a/packages/components/src/Modal/styles.ts
+++ b/packages/components/src/Modal/styles.ts
@@ -99,7 +99,7 @@ export function useModalStyles(props: ModalProps) {
 
   const styles = {
     overlay: [
-      tw`fixed inset-0 z-50 transition-opacity backdrop-blur-1 `,
+      tw`fixed inset-0 z-10000 transition-opacity backdrop-blur-1 `,
       open
         ? css`
             animation: ${overlayAnimationIn ?? animateOverlayIn} ${animationDuration}ms ease-in;
@@ -110,7 +110,7 @@ export function useModalStyles(props: ModalProps) {
     ],
     overlayInner: [tw`absolute inset-0 bg-gray-700 opacity-75`],
     container: [
-      tw`fixed inset-0 z-50 flex p-10 items-start`,
+      tw`fixed inset-0 z-10000 flex p-10 items-start`,
       open
         ? css`
             animation: ${modalAnimationIn ?? animateModalIn} ${animationDuration}ms ease-in;
@@ -120,7 +120,7 @@ export function useModalStyles(props: ModalProps) {
           `,
     ],
     content: [
-      tw`relative z-50 flex flex-col flex-1 w-full overflow-auto scrolling-touch transition-all transform bg-white`,
+      tw`relative z-10000 flex flex-col flex-1 w-full overflow-auto scrolling-touch transition-all transform bg-white`,
       tw`max-h-(screen-20) outline-none rounded-xl shadow-lg`,
       center ? tw`m-auto` : tw`mx-auto`,
       sizeStyle,

--- a/packages/utils/src/styles/tailwind.config.js
+++ b/packages/utils/src/styles/tailwind.config.js
@@ -34,7 +34,7 @@ export default {
         inherit: 'inherit',
       },
       zIndex: {
-        10000: 1000,
+        10000: 10000,
       },
       lineHeight: {
         inherit: 'inherit',

--- a/packages/utils/src/styles/tailwind.config.js
+++ b/packages/utils/src/styles/tailwind.config.js
@@ -33,6 +33,9 @@ export default {
       fontFamily: {
         inherit: 'inherit',
       },
+      zIndex: {
+        10000: 1000,
+      },
       lineHeight: {
         inherit: 'inherit',
       },


### PR DESCRIPTION
Increase the `z-index` value of `Modal` to 10000 to somewhat avoid it being overlapped by other elements.