### PR TITLE
fix: input style being overridden by theme CSS

### DIFF
--- a/.changeset/spicy-lies-impress.md
+++ b/.changeset/spicy-lies-impress.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Add additional styling for `Combobox`'s input to somewhat avoid its styles being overridden by external CSS.

--- a/packages/components/src/Combobox/styles.ts
+++ b/packages/components/src/Combobox/styles.ts
@@ -68,7 +68,7 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
     iconContainerRight: [...iconContainerStyles, tw`right-0`],
     input: [
       tw`form-input`,
-      tw`absolute inset-0 w-full bg-transparent border-0 focus:shadow-none font-inherit`,
+      tw`absolute inset-0 w-full h-full bg-transparent border-0 focus:shadow-none font-inherit m-0 p-0`,
       ...containerStyles,
       ` &::-ms-clear,
         &::-ms-reveal {


### PR DESCRIPTION
Add additional styling for `Combobox`'s input to somewhat avoid its styles being overridden by external CSS. This issue was spotted on https://jp2x4e97xnpvihev-26763868.shopifypreview.com/search?q=hello&viewType=list as the input looks off due to a margin issue.

**Before**:
![image](https://user-images.githubusercontent.com/12707960/114484704-e3dbd700-9c34-11eb-8d19-2a73133080d6.png)

**After**:
![image](https://user-images.githubusercontent.com/12707960/114484767-0241d280-9c35-11eb-9a41-5c08683acc1c.png)

Note that this is a partial fix to avoid the strange styling issue. If the styling looks crash, we should consider using `importantStyles` in the Context - https://react.docs.sajari.com/styling#important-styles.
