### PR TITLE
feat: add option to hide records count

### DIFF
--- a/.changeset/sixty-numbers-vanish.md
+++ b/.changeset/sixty-numbers-vanish.md
@@ -1,0 +1,6 @@
+---
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Add option to hide records count on filter components.

--- a/docs/pages/search-ui/filter.mdx
+++ b/docs/pages/search-ui/filter.mdx
@@ -439,6 +439,7 @@ Exclusive props if `type` is `list`.
 | `renderItem`    | `(value:string) => React.ReactNode` | -                                                | A render prop function is used to custom the item label rather than just displaying text.                                                                                                     |
 | `format`        | `'default'` \| `'price'`            | `default`                                        | How to format the values.                                                                                                                                                                     |
 | `placeholder`   | `string`                            | `'Search'`                                       | Placeholder for search input.                                                                                                                                                                 |
+| `hideCount`     | `boolean`                           | `false`                                          | Hide total items count.                                                                                                                                                                       |
 
 ### Color Props
 
@@ -453,10 +454,11 @@ Exclusive props if `type` is `color`.
 
 Exclusive props if `type` is `rating`.
 
-| Name    | Type     | Default | Description                 |
-| ------- | -------- | ------- | --------------------------- |
-| `name`  | `string` | -       | The name of a given Filter. |
-| `title` | `string` | -       | Title of the filter list.   |
+| Name        | Type      | Default | Description                 |
+| ----------- | --------- | ------- | --------------------------- |
+| `name`      | `string`  | -       | The name of a given Filter. |
+| `title`     | `string`  | -       | Title of the filter list.   |
+| `hideCount` | `boolean` | `false` | Hide total items count.     |
 
 ### Tabs Props
 
@@ -468,6 +470,7 @@ Exclusive props if `type` is `tabs`.
 | `limit`         | `number`                           | `15`                              | Maximum number of tabs.                                                                                                                                                                      |
 | `sort`          | `'count'` \| `'alpha'` \| `'none'` | `'count'`                         | How to sort the tabs. `'alpha'` stands for `'alphanumeric'` meaning to sort the items based on label alphabetically, `'count'` to sort based on count, `'none'` to skip the sorting process. |
 | `sortAscending` | `boolean`                          | `true` if `sort` is not `'count'` | Whether to sort in ascending order.                                                                                                                                                          |
+| `hideCount`     | `boolean`                          | `false`                           | Hide total items count.                                                                                                                                                                      |
 
 ### Range Props
 
@@ -490,3 +493,4 @@ Exclusive props if `type` is `select`.
 | `format`        | `'default'` \| `'price'`           | `default`                         | How to format the values.                                                                                                                                                                       |
 | `sort`          | `'count'` \| `'alpha'` \| `'none'` | `'count'`                         | How to sort the options. `'alpha'` stands for `'alphanumeric'` meaning to sort the items based on label alphabetically, `'count'` to sort based on count, `'none'` to skip the sorting process. |
 | `sortAscending` | `boolean`                          | `true` if `sort` is not `'count'` | Whether to sort in ascending order.                                                                                                                                                             |
+| `hideCount`     | `boolean`                          | `false`                           | Hide total items count.                                                                                                                                                                         |

--- a/packages/search-ui/src/Filter/ListFilter.tsx
+++ b/packages/search-ui/src/Filter/ListFilter.tsx
@@ -21,6 +21,7 @@ const ListFilter = (props: Omit<ListFilterProps, 'type'>) => {
     itemRender,
     placeholder = '',
     format,
+    hideCount = false,
   } = props;
 
   const filterContainerId = `list-${name}`;
@@ -116,7 +117,7 @@ const ListFilter = (props: Omit<ListFilterProps, 'type'>) => {
           >
             {typeof itemRender === 'function' ? itemRender(label) : formatLabel(label, { format, currency, t })}
           </Control>
-          <span css={styles.count}>{count.toLocaleString(language)}</span>
+          {!hideCount && <span css={styles.count}>{count.toLocaleString(language)}</span>}
         </CoreBox>
       )),
     [JSON.stringify(items), itemRender, selected],

--- a/packages/search-ui/src/Filter/RatingFilter.tsx
+++ b/packages/search-ui/src/Filter/RatingFilter.tsx
@@ -5,7 +5,7 @@ import { useSearchUIContext } from '../ContextProvider';
 import ListFilter from './ListFilter';
 import { RatingFilterProps } from './types';
 
-const RatingFilter = ({ name, title }: Omit<RatingFilterProps, 'type'>) => {
+const RatingFilter = ({ name, title, hideCount }: Omit<RatingFilterProps, 'type'>) => {
   const { ratingMax, disableDefaultStyles, customClassNames } = useSearchUIContext();
 
   const renderRating = useCallback(
@@ -30,6 +30,7 @@ const RatingFilter = ({ name, title }: Omit<RatingFilterProps, 'type'>) => {
       sortAscending={false}
       pinSelected={false}
       itemRender={renderRating}
+      hideCount={hideCount}
     />
   );
 };

--- a/packages/search-ui/src/Filter/SelectFilter.tsx
+++ b/packages/search-ui/src/Filter/SelectFilter.tsx
@@ -10,7 +10,7 @@ import { SelectFilterProps } from './types';
 import { formatLabel } from './utils';
 
 const SelectFilter = (props: Omit<SelectFilterProps, 'type'>) => {
-  const { name, title, sort = 'count', sortAscending = sort !== 'count', format } = props;
+  const { name, title, sort = 'count', sortAscending = sort !== 'count', format, hideCount = false } = props;
   const { options, reset, setSelected, selected, multi } = useFilter(name, { sort, sortAscending });
   const { disableDefaultStyles = false, customClassNames, currency } = useSearchUIContext();
   const { t } = useTranslation('filter');
@@ -48,7 +48,7 @@ const SelectFilter = (props: Omit<SelectFilterProps, 'type'>) => {
           optionClassName={customClassNames.filter?.select?.option}
         >
           {options.map(({ value, label, count }) => (
-            <Option value={label} key={value} label={count.toLocaleString()}>
+            <Option value={label} key={value} label={hideCount ? undefined : count.toLocaleString()}>
               {formatLabel(label, { format, currency, t })}
             </Option>
           ))}

--- a/packages/search-ui/src/Filter/TabFilter.tsx
+++ b/packages/search-ui/src/Filter/TabFilter.tsx
@@ -10,7 +10,15 @@ import { TabFilterProps } from './types';
 import { formatLabel } from './utils';
 
 const TabFilter = (props: Omit<TabFilterProps, 'type'>) => {
-  const { name, title, limit = 15, sort = 'count', sortAscending = sort !== 'count', format } = props;
+  const {
+    name,
+    title,
+    limit = 15,
+    sort = 'count',
+    sortAscending = sort !== 'count',
+    format,
+    hideCount = false,
+  } = props;
   const { t } = useTranslation('filter');
   const theme = useTheme();
   const { options, setSelected, selected } = useFilter(name, { sort, sortAscending });
@@ -45,17 +53,19 @@ const TabFilter = (props: Omit<TabFilterProps, 'type'>) => {
             selectedClassName={customClassNames.filter?.tabs?.selectedTab}
           >
             {`${formatLabel(label, { format, currency, t })}`}
-            <Box
-              as="span"
-              css={[
-                tw`py-0.5 px-1 rounded ml-3 text-xs leading-tight transition-colors`,
-                index === selectedIndex
-                  ? { backgroundColor: theme.color.primary.active, color: theme.color.primary.text }
-                  : tw`text-gray-500 bg-gray-100`,
-              ]}
-            >
-              {count.toLocaleString(language)}
-            </Box>
+            {!hideCount && (
+              <Box
+                as="span"
+                css={[
+                  tw`py-0.5 px-1 rounded ml-3 text-xs leading-tight transition-colors`,
+                  index === selectedIndex
+                    ? { backgroundColor: theme.color.primary.active, color: theme.color.primary.text }
+                    : tw`text-gray-500 bg-gray-100`,
+                ]}
+              >
+                {count.toLocaleString(language)}
+              </Box>
+            )}
           </Tab>
         ))}
       </TabList>

--- a/packages/search-ui/src/Filter/types.ts
+++ b/packages/search-ui/src/Filter/types.ts
@@ -35,6 +35,8 @@ export interface ListFilterProps extends BaseFilterProps {
   sortAscending?: boolean;
   /** How to format the values */
   format?: 'default' | 'price';
+  /** Hide total items count */
+  hideCount?: boolean;
 }
 
 export interface ColorFilterProps extends BaseFilterProps {
@@ -43,12 +45,16 @@ export interface ColorFilterProps extends BaseFilterProps {
 
 export interface RatingFilterProps extends BaseFilterProps {
   type: 'rating';
+  /** Hide total items count */
+  hideCount?: boolean;
 }
 
 export interface TabFilterProps
   extends BaseFilterProps,
     Pick<ListFilterProps, 'format' | 'limit' | 'sort' | 'sortAscending'> {
   type: 'tabs';
+  /** Hide total items count */
+  hideCount?: boolean;
 }
 
 export interface RangeFilterProps
@@ -59,6 +65,8 @@ export interface RangeFilterProps
 
 export interface SelectFilterProps extends BaseFilterProps, Pick<ListFilterProps, 'format' | 'sort' | 'sortAscending'> {
   type: 'select';
+  /** Hide total items count */
+  hideCount?: boolean;
 }
 
 export type FilterProps =


### PR DESCRIPTION
Add option to hide records count on filter components.

**Default**:

![image](https://user-images.githubusercontent.com/12707960/114796205-98533580-9dba-11eb-8dd1-33ca9b3d5060.png)


**With `hideCount`**:

![image](https://user-images.githubusercontent.com/12707960/114796262-b91b8b00-9dba-11eb-8869-1f978479b507.png)

