### PR TITLE
fix: formatLabel returns undefined for empty string

### DIFF
--- a/.changeset/curvy-pets-rule.md
+++ b/.changeset/curvy-pets-rule.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': patch
+'sajari-sdk-docs': patch
+---
+
+Fix return `undefined` if passing empty string to `formatLabel`.

--- a/packages/search-ui/src/Filter/test/utils.test.ts
+++ b/packages/search-ui/src/Filter/test/utils.test.ts
@@ -1,6 +1,7 @@
 import { FilterItem } from '@sajari/react-hooks';
 
-import { pinItems } from '../utils';
+import { TextTransform } from '../types';
+import { formatLabel, pinItems } from '../utils';
 
 describe('pinItems', () => {
   test.each([
@@ -77,4 +78,27 @@ describe('pinItems', () => {
   ])("pinItems(%o, %o, 'label')", (list: FilterItem[], pinned, expected) => {
     expect(pinItems(list, pinned, 'label')).toStrictEqual(expected);
   });
+});
+
+describe('formatLabel', () => {
+  const t = (s) => s;
+  test.each([
+    ['', 'normal-case', 'default', ''],
+    ['', 'uppercase', 'default', ''],
+    ['', 'capitalize', 'default', ''],
+    ['', 'capitalize-first-letter', 'default', ''],
+    ['all', 'capitalize-first-letter', 'default', 'All'],
+
+    ['text', 'normal-case', 'default', 'text'],
+    ['Car Electronics & GPS', 'uppercase', 'default', 'CAR ELECTRONICS & GPS'],
+    ['Car Electronics & GPS', 'lowercase', 'default', 'car electronics & gps'],
+    ['Car Electronics & GPS', 'capitalize', 'default', 'Car Electronics & GPS'],
+
+    ['> 200', 'normal-case', 'price', 'rangeOver'],
+  ])(
+    'formatLabel(%s, {textTransform:%s, format:%s})',
+    (label: string, textTransform: TextTransform, format: 'default' | 'price', expected) => {
+      expect(formatLabel(label, { textTransform, format, t })).toStrictEqual(expected);
+    },
+  );
 });

--- a/packages/search-ui/src/Filter/utils.ts
+++ b/packages/search-ui/src/Filter/utils.ts
@@ -62,7 +62,7 @@ export function formatLabel(input: string, params: FormatValueParams) {
         case 'capitalize':
           return input.replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase());
         case 'capitalize-first-letter':
-          return input[0]?.toLocaleUpperCase() + input.slice(1);
+          return (input[0] || '').toLocaleUpperCase() + input.slice(1);
         case 'normal-case':
         default:
           return input;


### PR DESCRIPTION
This issue was noticed in the integration builder as `undefined` text is displayed if the option text is an empty string.

![image](https://user-images.githubusercontent.com/12707960/114995166-bc506d00-9ec7-11eb-8875-c6e66c738ec4.png)
