### PR TITLE
fix: missing showPoweredBy prop in Input

### DIFF
--- a/.changeset/unlucky-suns-drive.md
+++ b/.changeset/unlucky-suns-drive.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': patch
+'sajari-sdk-docs': patch
+---
+
+Enable `showPoweredBy` prop for Input to show/hide Sajari logo.

--- a/packages/search-ui/src/Input/types.ts
+++ b/packages/search-ui/src/Input/types.ts
@@ -3,7 +3,7 @@ import { ComboboxProps } from '@sajari/react-components';
 export interface InputProps<T>
   extends Pick<
     ComboboxProps<T>,
-    'placeholder' | 'onSelect' | 'onChange' | 'inputElement' | 'enableVoice' | 'className'
+    'placeholder' | 'onSelect' | 'onChange' | 'inputElement' | 'enableVoice' | 'className' | 'showPoweredBy'
   > {
   mode?: ComboboxProps<T>['mode'] | 'instant';
   /* Sets how many autocomplete suggestions are shown in the box below the search input */


### PR DESCRIPTION
Enable `showPoweredBy` prop for Input to show/hide Sajari logo.