### PR TITLE
fix: styling being overridden by external CSS

### DIFF
--- a/.changeset/tough-pets-hope.md
+++ b/.changeset/tough-pets-hope.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Prevent styling of components from being overridden by external CSS such as Shopify themes.

--- a/packages/components/src/Button/styles.ts
+++ b/packages/components/src/Button/styles.ts
@@ -20,7 +20,7 @@ const useButtonStyles = (props: UseButtonStylesProps) => {
   const returnStyles = (val: typeof styles) => ({ styles: [css(val), focusRingStyles], focusRingProps });
 
   styles.push(
-    tw`relative items-center justify-center leading-normal no-underline transition duration-150 ease-in-out border border-transparent border-solid cursor-pointer font-inherit focus:outline-none`,
+    tw`relative items-center justify-center leading-normal no-underline transition duration-150 ease-in-out border border-transparent border-solid cursor-pointer font-inherit focus:outline-none h-auto`,
   );
 
   if (!isLink) {
@@ -116,7 +116,6 @@ const useButtonStyles = (props: UseButtonStylesProps) => {
   }
 
   switch (appearance) {
-    // TODO: test theming for primary appearance, we might want to change them later
     case 'primary':
       styles.push(`color: ${theme.color.primary.text};`);
 
@@ -132,19 +131,24 @@ const useButtonStyles = (props: UseButtonStylesProps) => {
     case 'default':
     case 'secondary':
       styles.push(
-        tw`bg-white border-gray-200 shadow-sm hover:bg-gray-100`,
-        appearance === 'secondary' ? `color: ${theme.color.primary.base};` : tw`text-gray-500`,
+        tw`bg-white border-gray-200 shadow-sm hover:bg-gray-100 focus:bg-gray-100`,
+        appearance === 'secondary'
+          ? `color: ${theme.color.primary.base};`
+          : tw`text-gray-500 hover:text-gray-500 focus:text-gray-500`,
       );
 
       if (pressed) {
-        styles.push(tw`bg-gray-100`);
+        styles.push(tw`bg-gray-100 focus:bg-gray-100 hover:bg-gray-100`);
       }
       break;
 
     case 'link':
-      styles.push(tw`p-0 no-underline bg-transparent hover:underline focus:underline leading-inherit`, {
-        color: pressed ? theme.color.primary.active : theme.color.primary.base,
-      });
+      styles.push(
+        tw`p-0 no-underline bg-transparent hover:bg-transparent focus:bg-transparent hover:underline focus:underline leading-inherit`,
+        {
+          color: pressed ? theme.color.primary.active : theme.color.primary.base,
+        },
+      );
 
       if (!loading && !pressed) {
         styles.push(`&:hover, &:focus { color: ${theme.color.primary.active} }`);

--- a/packages/components/src/Button/test/__snapshots__/Button.test.tsx.snap
+++ b/packages/components/src/Button/test/__snapshots__/Button.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`Button Should match snapshot 1`] = `
   border-style: solid;
   cursor: pointer;
   font-family: inherit;
+  height: auto;
   font-weight: 500;
   border-radius: 0.375rem;
   -webkit-user-select: none;
@@ -59,6 +60,21 @@ exports[`Button Should match snapshot 1`] = `
 .emotion-0:hover {
   --bg-opacity: 1;
   background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-0:focus {
+  --bg-opacity: 1;
+  background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-0:hover {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
+}
+
+.emotion-0:focus {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
 }
 
 <button

--- a/packages/components/src/ButtonGroup/test/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/packages/components/src/ButtonGroup/test/__snapshots__/ButtonGroup.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`ButtonGroup attached and inline 1`] = `
   border-style: solid;
   cursor: pointer;
   font-family: inherit;
+  height: auto;
   font-weight: 500;
   border-radius: 0.375rem;
   -webkit-user-select: none;
@@ -117,6 +118,21 @@ exports[`ButtonGroup attached and inline 1`] = `
 .emotion-2:hover {
   --bg-opacity: 1;
   background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:focus {
+  --bg-opacity: 1;
+  background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:hover {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
+}
+
+.emotion-2:focus {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
 }
 
 <div
@@ -229,6 +245,7 @@ exports[`ButtonGroup attached and not inline 1`] = `
   border-style: solid;
   cursor: pointer;
   font-family: inherit;
+  height: auto;
   font-weight: 500;
   border-radius: 0.375rem;
   -webkit-user-select: none;
@@ -261,6 +278,21 @@ exports[`ButtonGroup attached and not inline 1`] = `
 .emotion-2:hover {
   --bg-opacity: 1;
   background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:focus {
+  --bg-opacity: 1;
+  background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:hover {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
+}
+
+.emotion-2:focus {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
 }
 
 <div
@@ -339,6 +371,7 @@ exports[`ButtonGroup not attached and inline 1`] = `
   border-style: solid;
   cursor: pointer;
   font-family: inherit;
+  height: auto;
   font-weight: 500;
   border-radius: 0.375rem;
   -webkit-user-select: none;
@@ -371,6 +404,21 @@ exports[`ButtonGroup not attached and inline 1`] = `
 .emotion-2:hover {
   --bg-opacity: 1;
   background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:focus {
+  --bg-opacity: 1;
+  background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:hover {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
+}
+
+.emotion-2:focus {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
 }
 
 <div
@@ -443,6 +491,7 @@ exports[`ButtonGroup not attached and not inline 1`] = `
   border-style: solid;
   cursor: pointer;
   font-family: inherit;
+  height: auto;
   font-weight: 500;
   border-radius: 0.375rem;
   -webkit-user-select: none;
@@ -475,6 +524,21 @@ exports[`ButtonGroup not attached and not inline 1`] = `
 .emotion-2:hover {
   --bg-opacity: 1;
   background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:focus {
+  --bg-opacity: 1;
+  background-color: rgba(244,245,247,var(--bg-opacity));
+}
+
+.emotion-2:hover {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
+}
+
+.emotion-2:focus {
+  --text-opacity: 1;
+  color: rgba(107,114,128,var(--text-opacity));
 }
 
 <div

--- a/packages/components/src/Checkbox/styles.ts
+++ b/packages/components/src/Checkbox/styles.ts
@@ -19,10 +19,10 @@ export function useCheckboxStyles(props: CheckboxProps) {
     container: [tw`flex items-center`],
     componentWrapper: [tw`relative inline-flex items-center`],
     inputWrapper: [tw`relative flex`, focusRingStyles],
-    label: [tw`ml-2`, sizeStyles],
+    label: [tw`ml-2 p-0`, sizeStyles],
     indeterminate: [tw`absolute inset-0 flex items-center justify-center pointer-events-none`],
     indeterminateInner: [tw`m-auto w-1/2 h-0.5 rounded-sm`, { backgroundColor: theme.color.primary.text }],
-    input: [tw`form-checkbox`, inputStyles],
+    input: [tw`form-checkbox m-0`, inputStyles],
   };
 
   if (invalid) {

--- a/packages/components/src/Label/styles.ts
+++ b/packages/components/src/Label/styles.ts
@@ -13,7 +13,7 @@ export default function useLabelStyles({ visuallyHidden, size }: LabelProps) {
     styles.container.push(tw`sr-only`);
   } else {
     const sizeStyles = useFontSize({ size });
-    styles.container.push(tw`inline-flex items-center m-0 cursor-pointer`, sizeStyles);
+    styles.container.push(tw`inline-flex items-center m-0 p-0 cursor-pointer`, sizeStyles);
   }
 
   return mapStyles(styles);

--- a/packages/components/src/Radio/styles.ts
+++ b/packages/components/src/Radio/styles.ts
@@ -15,10 +15,10 @@ export default function useRadioStyles(props: RadioProps) {
 
   const styles = {
     container: [tw`flex items-center`],
-    label: [tw`ml-2`, sizeStyles],
+    label: [tw`ml-2 p-0`, sizeStyles],
     componentWrapper: [tw`inline-flex items-center`],
     inputWrapper: [tw`relative flex`, focusRingStyles],
-    input: [[tw`form-radio`, inputStyles]],
+    input: [[tw`form-radio m-0`, inputStyles]],
   };
 
   if (invalid) {

--- a/packages/components/src/RangeInput/components/Handle/styles.ts
+++ b/packages/components/src/RangeInput/components/Handle/styles.ts
@@ -12,7 +12,7 @@ export default function useHandleStyles(props: HandleProps) {
 
   const styles = {
     container: [
-      tw`w-4 h-4 transition duration-200 bg-white border-none rounded-full outline-none appearance-none cursor-pointer font-inherit leading-inherit before:(absolute transform -translate-x-1/2 text-xs px-1 rounded mb-1 bg-gray-900 bg-opacity-75 text-white text-center transition-opacity duration-200)`,
+      tw`w-4 h-4 p-0 m-0 transition duration-200 bg-white hover:bg-white focus:bg-white border-none rounded-full outline-none appearance-none cursor-pointer font-inherit leading-inherit before:(absolute transform -translate-x-1/2 text-xs px-1 rounded mb-1 bg-gray-900 bg-opacity-75 text-white text-center transition-opacity duration-200)`,
       {
         boxShadow: `inset 0 0 0 1px ${colorShadow.alpha(0.15).hsl()},
             inset 0 -1px 0 ${colorShadow.alpha(0.15).hsl()},

--- a/packages/components/src/Select/components/Button/styles.ts
+++ b/packages/components/src/Select/components/Button/styles.ts
@@ -12,7 +12,7 @@ export function useButtonStyles(params: UseButtonStylesParams) {
     ...params,
   } as UseInputStyleProps);
 
-  const styles = { container: [tw`form-select`, inputStyles] };
+  const styles = { container: [tw`form-select h-auto`, inputStyles] };
 
   return { styles: mapStyles(styles), focusRingProps, focusRingStyles };
 }


### PR DESCRIPTION
Prevent styling of components from being overridden by external CSS such as Shopify themes. Mostly, issues come from the box model properties and background and text color in focus and hover state. 