### PR TITLE
fix: input attach mode register/unregister callback correctly

### DIFF
--- a/.changeset/soft-cameras-brush.md
+++ b/.changeset/soft-cameras-brush.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+---
+
+Correctly register/unregister callback in attach mode


### PR DESCRIPTION
The `onKeyDown` was incorrectly registered (the `highlightedIndex` is wrong in the callback) so `onSelect` was never called when pressing `Enter` key.