### PR TITLE
fix: color filter value

### DIFF
--- a/.changeset/large-cars-grow.md
+++ b/.changeset/large-cars-grow.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Fix ColorFilter component sending wrong filter value

--- a/packages/search-ui/src/Filter/ColorFilter.tsx
+++ b/packages/search-ui/src/Filter/ColorFilter.tsx
@@ -6,6 +6,7 @@ import React, { useMemo } from 'react';
 import { useSearchUIContext } from '../ContextProvider';
 import Box from './Box';
 import { ColorFilterProps } from './types';
+import { capitalize } from './utils';
 
 const { colorKeys } = Swatch;
 
@@ -13,15 +14,17 @@ const ColorFilter = ({ name, title }: Omit<ColorFilterProps, 'type'>) => {
   const { options, selected, setSelected, reset } = useFilter(name);
   const { customClassNames, disableDefaultStyles = false } = useSearchUIContext();
   const optionKeys = useMemo(() => options.map((o) => o.label), [JSON.stringify(options)]);
-  const filtered = useMemo(() => colorKeys.filter((c) => optionKeys.some((o) => c.toLowerCase() === o.toLowerCase())), [
+  const filtered = useMemo(() => optionKeys.filter((c) => colorKeys.some((o) => c.toLowerCase() === o.toLowerCase())), [
     JSON.stringify(optionKeys),
   ]);
 
   const children = useMemo(
     () =>
       filtered.map((color) => {
-        const Component = Swatch.Color[color];
-        return <Component key={color} />;
+        // We capitalize to get the pre-defined color component
+        const Component = Swatch.Color[capitalize(color)];
+        // `id` prop should override the default so that cases like `red` will be included in search request as-is and not `Red`
+        return <Component key={color} id={color} />;
       }),
     [JSON.stringify(filtered)],
   );

--- a/packages/search-ui/src/Filter/test/utils.test.ts
+++ b/packages/search-ui/src/Filter/test/utils.test.ts
@@ -1,7 +1,7 @@
 import { FilterItem } from '@sajari/react-hooks';
 
 import { TextTransform } from '../types';
-import { formatLabel, pinItems } from '../utils';
+import { capitalize, formatLabel, pinItems } from '../utils';
 
 describe('pinItems', () => {
   test.each([
@@ -101,4 +101,15 @@ describe('formatLabel', () => {
       expect(formatLabel(label, { textTransform, format, t })).toStrictEqual(expected);
     },
   );
+});
+
+describe('capitalize', () => {
+  test.each([
+    ['', ''],
+    ['red', 'Red'],
+    ['picton Blue', 'Picton Blue'],
+    ['crimsonred', 'Crimsonred'],
+  ])('capitalize(%s)', (input, output) => {
+    expect(capitalize(input)).toBe(output);
+  });
 });

--- a/packages/search-ui/src/Filter/utils.ts
+++ b/packages/search-ui/src/Filter/utils.ts
@@ -30,6 +30,15 @@ interface FormatValueParams {
 }
 
 /**
+ * Capitalize a string value
+ * @param {string} the string to be capitalized
+ * @returns {string} the capitalized value
+ */
+export function capitalize(value: string): string {
+  return value.replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase());
+}
+
+/**
  * Format a value to be presented in the UI
  * @param input - the value to format
  * @param params - formatting options
@@ -60,7 +69,7 @@ export function formatLabel(input: string, params: FormatValueParams) {
         case 'lowercase':
           return input.toLocaleLowerCase();
         case 'capitalize':
-          return input.replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase());
+          return capitalize(input);
         case 'capitalize-first-letter':
           return (input[0] || '').toLocaleUpperCase() + input.slice(1);
         case 'normal-case':


### PR DESCRIPTION
## What this PR does

Fixes the bug where incorrect color filter value is included in the search request, this is due to the internal logic of `ColorFilter` as it always convert the filter value response received from backend to be capitalized which leads to this:
![Screen Shot 2021-04-29 at 11 12 56](https://user-images.githubusercontent.com/25856620/116501862-227fbb80-a8dc-11eb-9fb9-f2e40ea56305.png)
![Screen Shot 2021-04-29 at 11 13 02](https://user-images.githubusercontent.com/25856620/116501863-24497f00-a8dc-11eb-8f22-4ca6f1f0b831.png)
