### PR TITLE
feat: add variant prop and 2xl size for Combobox

### DIFF
--- a/.changeset/spotty-vans-fetch.md
+++ b/.changeset/spotty-vans-fetch.md
@@ -1,0 +1,7 @@
+---
+'sajari-sdk-docs': patch
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+---
+
+Add `variant` prop and `2xl` option for `size` prop for Combobox.

--- a/docs/pages/components/combobox.mdx
+++ b/docs/pages/components/combobox.mdx
@@ -22,6 +22,17 @@ import { Combobox } from 'sajari/react-components';
 <Combobox />
 ```
 
+### Variants
+
+The compobox component comes in 2 variants: `outline` and `unstyled`. Pass the variant prop and set it to one of these values.
+
+```jsx
+<div className="space-y-3">
+  <Combobox variant="outline" />
+  <Combobox variant="unstyled" />
+</div>
+```
+
 ### Sizes
 
 Use the `size` prop to set the size of the combobox. The default is `md`.
@@ -31,6 +42,7 @@ Use the `size` prop to set the size of the combobox. The default is `md`.
   <Combobox size="sm" />
   <Combobox size="md" />
   <Combobox size="lg" />
+  <Combobox size="2xl" />
 </div>
 ```
 
@@ -152,3 +164,5 @@ Set the `mode` prop to `typeahead` to render a typeahead suggestion.
 | `itemToString`      | `(item:T) => string`                                            |              | A callback to convert item (object) to string.                                                                                                                                                                                                                                                            |
 | `itemToUrl`         | `(item:T) => string`                                            |              | A callback to get/compute url from item object for results mode.                                                                                                                                                                                                                                          |
 | `renderItem`        | `(params) => React.ReactNode`                                   |              | A render prop function for customizing result item view.                                                                                                                                                                                                                                                  |
+| `size`              | `'sm'` \| `'md'` \| `'lg'` \| `'2xl'`                           | `md`         | The size of the combobox.                                                                                                                                                                                                                                                                                 |
+| `variant`           | `'outline'` \| `'unstyled'`                                     | `outline`    | The appearance of the combobox.                                                                                                                                                                                                                                                                           |

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -50,6 +50,7 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     inputContainerClassName,
     inputElement,
     autoFocus = false,
+    variant = 'outline',
     ...rest
   } = props;
   const [typedInputValue, setTypedInputValue] = useState(valueProp.toString());
@@ -251,6 +252,7 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     size,
     voiceEnabled: enableVoice && voiceSupported,
     loading,
+    variant,
   });
 
   const styles = getStylesObject(comboboxStyles, disableDefaultStyles);
@@ -368,7 +370,7 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
             </Box>
 
             <Box css={styles.iconContainerLeft} className={inputContainerClassName}>
-              {size === 'sm' ? <IconSmallSearch /> : <IconSearch />}
+              {size === 'sm' ? <IconSmallSearch /> : <IconSearch css={styles.iconSearch} />}
             </Box>
 
             <Typeahead />

--- a/packages/components/src/Combobox/styles.ts
+++ b/packages/components/src/Combobox/styles.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { inferStylesObjectKeys, mapStyles } from '@sajari/react-sdk-utils';
 import tw, { TwStyle } from 'twin.macro';
 
@@ -5,17 +6,18 @@ import { useFocusRingStyles } from '../hooks';
 import { ComboboxProps } from './types';
 
 interface UseComboboxStylesProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   size: ComboboxProps<any>['size'];
   voiceEnabled: boolean;
   loading: boolean;
+  variant: ComboboxProps<any>['variant'];
 }
 
 export function useComboboxStyles(props: UseComboboxStylesProps) {
-  const { size, voiceEnabled, loading } = props;
+  const { size, voiceEnabled, loading, variant } = props;
   const { focusProps, focusRingStyles } = useFocusRingStyles();
   const containerStyles: TwStyle[] = [];
   const iconContainerStyles: TwStyle[] = [tw`absolute inset-y-0 flex items-center space-x-2 text-gray-400`];
+  const iconSearchStyles: TwStyle[] = [];
 
   switch (size) {
     case 'sm':
@@ -28,6 +30,19 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
       }
 
       iconContainerStyles.push(tw`px-2`);
+      break;
+
+    case '2xl':
+      containerStyles.push(tw`py-3 text-2xl pl-13`);
+
+      if (loading && voiceEnabled) {
+        containerStyles.push(tw`pr-15`);
+      } else if (loading || voiceEnabled) {
+        containerStyles.push(tw`pr-11`);
+      }
+
+      iconContainerStyles.push(tw`px-3.5 text-lg`);
+      iconSearchStyles.push(tw`w-6 h-6`);
       break;
 
     case 'lg':
@@ -58,12 +73,7 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
 
   const styles = inferStylesObjectKeys({
     container: [tw`relative`],
-    inputContainer: [
-      tw`form-input`,
-      tw`relative text-base transition-all duration-150 bg-white border border-gray-200 border-solid`,
-      ...focusRingStyles,
-      ...containerStyles,
-    ],
+    inputContainer: [tw`form-input`, tw`relative text-base transition-all duration-150`, ...containerStyles],
     iconContainerLeft: [...iconContainerStyles, tw`left-0`],
     iconContainerRight: [...iconContainerStyles, tw`right-0`],
     input: [
@@ -84,10 +94,19 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
         }`,
     ],
     iconSpinner: [],
+    iconSearch: iconSearchStyles,
   });
+
+  if (variant === 'outline') {
+    styles.inputContainer.push(...[tw`bg-white border border-gray-200 border-solid`, ...focusRingStyles]);
+  } else {
+    styles.inputContainer.push(tw`border-none py-0`);
+  }
 
   if (size === 'sm') {
     styles.iconSpinner.push(tw`w-3 h-3`);
+  } else if (size === '2xl') {
+    styles.iconSpinner.push(tw`w-5 h-5`);
   }
 
   return { styles: mapStyles(styles), focusProps };

--- a/packages/components/src/Combobox/types.ts
+++ b/packages/components/src/Combobox/types.ts
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { BoxProps } from '../Box';
 
 export type ComboboxMode = 'standard' | 'typeahead' | 'suggestions' | 'results';
+export type ComboboxVariant = 'outline' | 'unstyled';
 
 export interface ResultItem {
   title: string;
@@ -71,7 +72,7 @@ interface Props<T> {
   /** The typeahead completion value */
   completion?: string;
   /** The size of the combobox input */
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | '2xl';
   /** Whether to show tips in the dropdown on how to navigate the options */
   showDropdownTips?: boolean;
   /** Whether to show the "Powered by Sajari" in the dropdown */
@@ -92,6 +93,8 @@ interface Props<T> {
   }) => React.ReactNode;
   /** The input element, used when you want to hook into an existing input element */
   inputElement?: React.RefObject<HTMLInputElement>;
+  /** Changing the appearance of the input */
+  variant?: ComboboxVariant;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/components/src/assets/icons/index.tsx
+++ b/packages/components/src/assets/icons/index.tsx
@@ -1,6 +1,7 @@
 import IconCheck from './check.svg';
 import IconChevronLeft from './chevron-left.svg';
 import IconChevronRight from './chevron-right.svg';
+import IconClose from './close.svg';
 import IconDownKey from './down-key.svg';
 import IconEmptyMic from './empty-mic.svg';
 import IconEnterKey from './enter-key.svg';
@@ -11,12 +12,12 @@ import IconSmallSearch from './small-search.svg';
 import IconSmallStar from './small-star.svg';
 import IconSpinner from './spinner.svg';
 import IconUpKey from './up-key.svg';
-import IconClose from './close.svg';
 
 export {
   IconCheck,
   IconChevronLeft,
   IconChevronRight,
+  IconClose,
   IconDownKey,
   IconEmptyMic,
   IconEnterKey,
@@ -27,5 +28,4 @@ export {
   IconSmallStar,
   IconSpinner,
   IconUpKey,
-  IconClose,
 };

--- a/packages/search-ui/src/Input/types.ts
+++ b/packages/search-ui/src/Input/types.ts
@@ -3,7 +3,15 @@ import { ComboboxProps } from '@sajari/react-components';
 export interface InputProps<T>
   extends Pick<
     ComboboxProps<T>,
-    'placeholder' | 'onSelect' | 'onChange' | 'inputElement' | 'enableVoice' | 'className' | 'showPoweredBy'
+    | 'placeholder'
+    | 'onSelect'
+    | 'onChange'
+    | 'inputElement'
+    | 'enableVoice'
+    | 'className'
+    | 'showPoweredBy'
+    | 'variant'
+    | 'size'
   > {
   mode?: ComboboxProps<T>['mode'] | 'instant';
   /* Sets how many autocomplete suggestions are shown in the box below the search input */


### PR DESCRIPTION
Add `unstyled` variant and `2xl` size for Combobox to tweak the design of overlay mode:

![image](https://user-images.githubusercontent.com/12707960/116503089-6fb15c80-a8df-11eb-8c87-2e8a6e110b78.png)
