### PR TITLE
feat: add list display for sorting component

### DIFF
--- a/.changeset/large-crabs-itch.md
+++ b/.changeset/large-crabs-itch.md
@@ -1,0 +1,6 @@
+---
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Support `list` display for `Sorting` component.

--- a/docs/pages/search-ui/sorting.mdx
+++ b/docs/pages/search-ui/sorting.mdx
@@ -74,7 +74,7 @@ function Example() {
 
 ## Display
 
-The sorting component comes in 2 variants: `inline` and `list`. Pass the variant prop and set it to one of these values.
+The sorting component comes in 2 variants: `select` and `list`. Pass the variant prop and set it to one of these values.
 
 ```jsx
 function Example() {

--- a/docs/pages/search-ui/sorting.mdx
+++ b/docs/pages/search-ui/sorting.mdx
@@ -38,8 +38,8 @@ function Example() {
         <div className="flex-1">
           <Input />
         </div>
-
         <Sorting
+          type="select" // or "list"
           options={[
             { name: 'Most relevant', value: '' },
             { name: 'Brand: A to Z', value: 'brand' },
@@ -72,11 +72,67 @@ function Example() {
 }
 ```
 
+## Display
+
+The sorting component comes in 2 variants: `inline` and `list`. Pass the variant prop and set it to one of these values.
+
+```jsx
+function Example() {
+  const pipeline = new Pipeline(
+    {
+      account: '1594153711901724220',
+      collection: 'bestbuy',
+    },
+    'query',
+  );
+
+  const SearchPlayground = React.memo(() => (
+    <div className="flex flex-col space-y-6">
+      <Input />
+
+      <div className="flex -mx-3">
+        <div className="w-1/4 px-3 border-gray-100 border-r space-y-6">
+          <Sorting
+            type="list"
+            options={[
+              { name: 'Most relevant', value: '' },
+              { name: 'Brand: A to Z', value: 'brand' },
+              { name: 'Brand: Z to A', value: '-brand' },
+              { name: 'Rating: Low to High', value: 'rating' },
+              { name: 'Rating: High to Low', value: '-rating' },
+              { name: 'Popularity', value: 'popularity' },
+            ]}
+          />
+        </div>
+        <div className="w-3/4 px-3">
+          <Results />
+        </div>
+      </div>
+    </div>
+  ));
+
+  return (
+    <SearchProvider
+      search={{
+        pipeline,
+        fields: new FieldDictionary({
+          title: 'name',
+          subtitle: (data) => data.level4 || data.level3 || data.level2 || data.level1 || data.brand,
+        }),
+      }}
+      searchOnLoad
+    >
+      <SearchPlayground />
+    </SearchProvider>
+  );
+}
+```
+
 ## Props
 
-| Name      | Type                                   | Default                                | Description                                 |
-| --------- | -------------------------------------- | -------------------------------------- | ------------------------------------------- |
-| `label`   | `string`                               | `"Sort"`                               |                                             |
-| `options` | `Array<{name: string, value: string}>` | `[{name: "Most relevant", value: ""}]` |                                             |
-| `size`    | `sm` \| `md` \| `lg`                   | `md`                                   | Sets the text and input size.               |
-| `inline`  | `boolean`                              | `true`                                 | Whether to render label and control inline. |
+| Name      | Type                                   | Default                                | Description                              |
+| --------- | -------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `label`   | `string`                               | `"Sort"`                               |                                          |
+| `type`    | `"select"` \| `"list"`                 | `"select"`                             | The appearance of the sorting component. |
+| `options` | `Array<{name: string, value: string}>` | `[{name: "Most relevant", value: ""}]` |                                          |
+| `size`    | `sm` \| `md` \| `lg`                   | `md`                                   | Sets the text and input size.            |

--- a/docs/pages/search-ui/sorting.mdx
+++ b/docs/pages/search-ui/sorting.mdx
@@ -39,7 +39,7 @@ function Example() {
           <Input />
         </div>
         <Sorting
-          type="select" // or "list"
+          type="select"
           options={[
             { name: 'Most relevant', value: '' },
             { name: 'Brand: A to Z', value: 'brand' },

--- a/packages/search-ui/src/Sorting/index.tsx
+++ b/packages/search-ui/src/Sorting/index.tsx
@@ -1,9 +1,10 @@
 import { useId } from '@react-aria/utils';
-import { Option, Select } from '@sajari/react-components';
+import { Option, Radio, RadioGroup, Select } from '@sajari/react-components';
 import { useSorting } from '@sajari/react-hooks';
-import { isArray } from '@sajari/react-sdk-utils';
+import { getStylesObject, isArray } from '@sajari/react-sdk-utils';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import tw from 'twin.macro';
 
 import { useSearchUIContext } from '../ContextProvider';
 import ViewOption from '../ViewOption';
@@ -13,10 +14,49 @@ const defaultOptions: SortOption[] = [{ name: 'Most relevant', value: '' }];
 
 const Sorting = (props: SortingProps) => {
   const { t } = useTranslation('sorting');
-  const { label = t('label'), options = defaultOptions, size, styles: stylesProp, ...rest } = props;
+  const { type = 'select', label = t('label'), options = defaultOptions, size, styles: stylesProp, ...rest } = props;
   const { disableDefaultStyles = false, customClassNames } = useSearchUIContext();
   const { sorting, setSorting } = useSorting();
   const id = `sorting-${useId()}`;
+  const styles = getStylesObject(
+    {
+      radioGroup: [tw`text-sm`],
+    },
+    disableDefaultStyles,
+  );
+
+  const innerRender =
+    type === 'select' ? (
+      <Select
+        id={id}
+        value={sorting}
+        onChange={(value) => setSorting(isArray(value) ? value[0] : value)}
+        size={size}
+        disableDefaultStyles={disableDefaultStyles}
+        className={customClassNames.sorting?.select}
+      >
+        {options.map((s: SortOption) => (
+          <Option key={s.value} value={s.value}>
+            {s.name}
+          </Option>
+        ))}
+      </Select>
+    ) : (
+      <RadioGroup
+        id={id}
+        value={sorting}
+        onChange={(e) => setSorting(e.target.value)}
+        className={customClassNames.filter?.list?.radioGroup}
+        css={styles.radioGroup}
+        disableDefaultStyles={disableDefaultStyles}
+      >
+        {options.map((s: SortOption) => (
+          <Radio key={s.value} value={s.value}>
+            {s.name}
+          </Radio>
+        ))}
+      </RadioGroup>
+    );
 
   return (
     <ViewOption
@@ -26,22 +66,10 @@ const Sorting = (props: SortingProps) => {
       className={customClassNames.sorting?.container}
       labelClassName={customClassNames.sorting?.label}
       renderAsLabel
+      inline={type === 'select'}
       {...rest}
     >
-      <Select
-        id={id}
-        value={sorting}
-        onChange={(value) => setSorting(isArray(value) ? value[0] : value)}
-        size={size}
-        disableDefaultStyles={disableDefaultStyles}
-        className={customClassNames.sorting?.select}
-      >
-        {options.map((s) => (
-          <Option key={s.value} value={s.value}>
-            {s.name}
-          </Option>
-        ))}
-      </Select>
+      {innerRender}
     </ViewOption>
   );
 };

--- a/packages/search-ui/src/Sorting/types.ts
+++ b/packages/search-ui/src/Sorting/types.ts
@@ -9,4 +9,5 @@ export type SortOption = {
 
 export interface SortingProps extends Omit<BoxProps, 'className'>, Pick<ViewOptionProps, 'label' | 'size' | 'inline'> {
   options?: SortOption[];
+  type: 'select' | 'list';
 }

--- a/packages/search-ui/src/ViewOption/styles.ts
+++ b/packages/search-ui/src/ViewOption/styles.ts
@@ -9,7 +9,10 @@ export default function useViewOptionStyles(params: UseViewOptionStyleParams) {
   const { inline } = params;
   const styles = {
     container: [tw`min-w-0`, inline ? tw`flex items-center space-x-2` : tw`space-y-1`],
-    label: [tw`text-gray-500`],
+    label: [
+      tw`text-gray-500`,
+      inline ? undefined : tw`text-gray-400 font-medium tracking-wide leading-snug text-xs uppercase`,
+    ].filter(Boolean),
   };
 
   return mapStyles(styles);


### PR DESCRIPTION
Add `list` display option for sorting component. This variant will be used for the mobile version of the overlay mode.

![image](https://user-images.githubusercontent.com/12707960/117662169-79816c80-b1c9-11eb-9c8a-a209a90fcc00.png)
