### PR TITLE
feat: support optional emitEvent for resetFilters

### DIFF
--- a/.changeset/nine-taxis-poke.md
+++ b/.changeset/nine-taxis-poke.md
@@ -1,0 +1,7 @@
+---
+'sajari-sdk-docs': patch
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+Allow `resetFilters` to optionally not emit subscribing events of filters. It is useful when we want to reset all filters to their default value but don't want to trigger a search request.

--- a/docs/pages/classes/filterbuilder.mdx
+++ b/docs/pages/classes/filterbuilder.mdx
@@ -71,24 +71,24 @@ The constructor accepts a single object with the following properties:
 
 For more advanced implementations, you may want to access properties on the `FilterBuilder` instance.
 
-| Name                                                               | Description                                                            |
-| ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| `listen(event: string, callback: (filter: FilterBuilder) => void)` | Register a listener for a specific event.                              |
-| `set(values: string[], merge: boolean = false)`                    | Set the state of the filter and optionally merge current values.       |
-| `reset()`                                                          | Reset the current filter to the initial one.                           |
-| `remove(values: string[])`                                         | Remove a list of values from the current state.                        |
-| `isSet(name: string)`                                              | Returns whether the filter is set or not.                              |
-| `setOptions(options: Options, merge: boolean = false)`             | Set or merge filter options.                                           |
-| `filter()`                                                         | Builds up the filter string from the current filter and it's children. |
-| `getBuckets()`                                                     | Get the bucket definitions for the filter.                             |
-| `getName()`                                                        | Returns the `name` property of the filter.                             |
-| `getGroup()`                                                       | Returns the `group` property of the filter.                            |
-| `getField()`                                                       | Returns the `field` property of the filter.                            |
-| `getCount()`                                                       | Returns the `count` property of the filter.                            |
-| `getOptions()`                                                     | Returns the current `options` property of the filter.                  |
-| `get()`                                                            | Returns the current selected options of the filter.                    |
-| `isArray()`                                                        | Returns the `array` property of the filter.                            |
-| `isMulti()`                                                        | Returns the `multi` property of the filter.                            |
+| Name                                                               | Description                                                               |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `listen(event: string, callback: (filter: FilterBuilder) => void)` | Register a listener for a specific event.                                 |
+| `set(values: string[], merge: boolean = false)`                    | Set the state of the filter and optionally merge current values.          |
+| `reset(emitEvent?: boolean)`                                       | Reset the current filter to the initial one and optionally emit an event. |
+| `remove(values: string[])`                                         | Remove a list of values from the current state.                           |
+| `isSet(name: string)`                                              | Returns whether the filter is set or not.                                 |
+| `setOptions(options: Options, merge: boolean = false)`             | Set or merge filter options.                                              |
+| `filter()`                                                         | Builds up the filter string from the current filter and it's children.    |
+| `getBuckets()`                                                     | Get the bucket definitions for the filter.                                |
+| `getName()`                                                        | Returns the `name` property of the filter.                                |
+| `getGroup()`                                                       | Returns the `group` property of the filter.                               |
+| `getField()`                                                       | Returns the `field` property of the filter.                               |
+| `getCount()`                                                       | Returns the `count` property of the filter.                               |
+| `getOptions()`                                                     | Returns the current `options` property of the filter.                     |
+| `get()`                                                            | Returns the current selected options of the filter.                       |
+| `isArray()`                                                        | Returns the `array` property of the filter.                               |
+| `isMulti()`                                                        | Returns the `multi` property of the filter.                               |
 
 ### Listen example
 

--- a/docs/pages/classes/rangefilterbuilder.mdx
+++ b/docs/pages/classes/rangefilterbuilder.mdx
@@ -70,7 +70,7 @@ For more advanced implementations, you may want to access properties on the `Fil
 | `listen(event: string, callback: (filter: RangeFilterBuilder) => void)` | Register a listener for a specific event.                                                     |
 | `get()`                                                                 | Get the current range of the filter.                                                          |
 | `set(range: [number, number] OR null, emitEvent: boolean)`              | Set the current range of the filter and optionally emit an event.                             |
-| `reset()`                                                               | Reset the current filter to the initial values.                                               |
+| `reset(emitEvent?: boolean)`                                            | Reset the current filter to the initial values.                                               |
 | `setMin(value: number)`                                                 | Set the minimum value.                                                                        |
 | `setMax(value: number)`                                                 | Set the maximum value.                                                                        |
 | `getMinMax()`                                                           | Returns the current min and max in an array.                                                  |

--- a/docs/pages/hooks/usesearchcontext.mdx
+++ b/docs/pages/hooks/usesearchcontext.mdx
@@ -95,20 +95,20 @@ function Example() {
 
 `useSearchContext` returns an object containing the following properties:
 
-| Name             | Type                  | Default | Description                                                      |
-| ---------------- | --------------------- | ------- | ---------------------------------------------------------------- |
-| `empty`          | `boolean`             |         | If the response was empty, indicating an issue with the request. |
-| `error`          | `Error` \| `null`     |         | The error encountered while searching.                           |
-| `latency`        | `number`              |         | The engine latency.                                              |
-| `page`           | `number`              |         | The current page.                                                |
-| `pageCount`      | `number`              |         | The total number of pages.                                       |
-| `queryValues`    | `Map<string, string>` |         | The query values from the response.                              |
-| `results`        | `Result[]`            |         | An array of results that met the query.                          |
-| `resultsPerPage` | `number`              |         | The number of results returned per page.                         |
-| `searched`       | `boolean`             |         | If an initial search has been performed.                         |
-| `searching`      | `boolean`             |         | Is a search request being processed.                             |
-| `totalResults`   | `number`              |         | The total count of results.                                      |
-| `clearFilters`   | `() => void`          |         | Reset all filters to its default value.                          |
+| Name             | Type                            | Default | Description                                                              |
+| ---------------- | ------------------------------- | ------- | ------------------------------------------------------------------------ |
+| `empty`          | `boolean`                       |         | If the response was empty, indicating an issue with the request.         |
+| `error`          | `Error` \| `null`               |         | The error encountered while searching.                                   |
+| `latency`        | `number`                        |         | The engine latency.                                                      |
+| `page`           | `number`                        |         | The current page.                                                        |
+| `pageCount`      | `number`                        |         | The total number of pages.                                               |
+| `queryValues`    | `Map<string, string>`           |         | The query values from the response.                                      |
+| `results`        | `Result[]`                      |         | An array of results that met the query.                                  |
+| `resultsPerPage` | `number`                        |         | The number of results returned per page.                                 |
+| `searched`       | `boolean`                       |         | If an initial search has been performed.                                 |
+| `searching`      | `boolean`                       |         | Is a search request being processed.                                     |
+| `totalResults`   | `number`                        |         | The total count of results.                                              |
+| `clearFilters`   | `(emitEvent?: boolean) => void` |         | Reset all filters to its default value and optionally emit their events. |
 
 ## Parameters
 

--- a/packages/hooks/src/ContextProvider/controllers/filters/FilterBuilder.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/FilterBuilder.ts
@@ -213,9 +213,11 @@ export default class FilterBuilder {
   /**
    * Reset the current filter to the initial one
    */
-  public reset() {
+  public reset(emitEvent = true) {
     this.current = [...this.initial];
-    this.emitSelectionUpdated();
+    if (emitEvent) {
+      this.emitSelectionUpdated();
+    }
   }
 
   /**

--- a/packages/hooks/src/ContextProvider/index.tsx
+++ b/packages/hooks/src/ContextProvider/index.tsx
@@ -304,8 +304,8 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
 
   const handleResultClicked = useCallback((url: string) => search.pipeline.emitResultClicked(url), []);
 
-  const resetFilters = () => {
-    search.filters?.forEach((f) => f?.reset());
+  const resetFilters = (emitEvent = true) => {
+    search.filters?.forEach((f) => f?.reset(emitEvent));
   };
 
   const getContext = (state: PipelineProviderState) =>

--- a/packages/hooks/src/ContextProvider/types.ts
+++ b/packages/hooks/src/ContextProvider/types.ts
@@ -4,7 +4,7 @@ import { FilterBuilder, Pipeline, RangeFilterBuilder, Response, Variables } from
 
 export type SearchFn = (query?: string, override?: boolean) => void;
 export type ClearFn = (variables?: { [k: string]: string | undefined }) => void;
-export type ResetFiltersFn = () => void;
+export type ResetFiltersFn = (emitEvent?: boolean) => void;
 export type ResultClickedFn = (url: string) => void;
 export type PaginateFn = (page: number) => void;
 


### PR DESCRIPTION
Allow `resetFilters` to optionally not emit subscribing events of filters. It is useful when we want to reset all filters to their default value but don't want to trigger a search request.