### PR TITLE
fix: broken input style

### DIFF
--- a/.changeset/hot-hounds-hide.md
+++ b/.changeset/hot-hounds-hide.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix style is broken on Combobox due to `box-sizing` being overridden.

--- a/packages/components/src/Combobox/styles.ts
+++ b/packages/components/src/Combobox/styles.ts
@@ -91,7 +91,7 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
     iconContainerRight: [...iconContainerStyles, tw`right-0`],
     input: [
       tw`form-input`,
-      tw`absolute inset-0 w-full h-full bg-transparent border-0 focus:border-0 outline-none focus:outline-none shadow-none focus:shadow-none font-inherit m-0 p-0`,
+      tw`absolute inset-0 w-full h-full bg-transparent border-0 focus:border-0 outline-none focus:outline-none shadow-none focus:shadow-none font-inherit m-0 p-0 box-border`,
       ...containerStyles,
       ` &::-ms-clear,
         &::-ms-reveal {


### PR DESCRIPTION
Fix style is broken on Combobox due to `box-sizing` being overridden.

![image](https://user-images.githubusercontent.com/12707960/118463657-3758ad80-b72a-11eb-9efc-b59c8b3392f3.png)
