### PR TITLE
fix: incorrect aggregate min max after query change

### DIFF
--- a/.changeset/dull-fans-grab.md
+++ b/.changeset/dull-fans-grab.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+Previously, changing query will remove range filters from the search request via the `reset` function but the update in https://github.com/sajari/sdk-react/commit/66761119165a94ec3a779e0c651ecfb77406dcba was causing the range filters to appear in the request so the return values of aggregate min and max are incorrect.

--- a/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
@@ -173,13 +173,29 @@ export default class RangeFilterBuilder {
       return;
     }
 
-    if (isArray(this.initial)) {
-      this.range = [...this.initial];
-    } else if (this.aggregate) {
+    if (this.initial === null && this.aggregate) {
       this.range = this.aggregateMaxRange;
+    } else if (isArray(this.initial)) {
+      this.range = [...this.initial];
     } else {
       this.range = this.initial;
     }
+
+    if (emitEvent) {
+      this.emitRangeUpdated();
+    }
+  }
+
+  /**
+   * Set null to the current range to exclude the filter from the search request
+   * so the the backend can aggregate the minimum and maximum values for a query
+   */
+  public aggregateReset(emitEvent = true) {
+    if (this.frozen && !this.isAggregate) {
+      return;
+    }
+
+    this.range = null;
 
     if (emitEvent) {
       this.emitRangeUpdated();

--- a/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
@@ -188,7 +188,7 @@ export default class RangeFilterBuilder {
 
   /**
    * Set null to the current range to exclude the filter from the search request
-   * so the the backend can aggregate the minimum and maximum values for a query
+   * so the the backend can aggregate the maximum range of [min, max] for a query
    */
   public aggregateReset(emitEvent = true) {
     if (this.frozen && !this.isAggregate) {

--- a/packages/hooks/src/useRangeFilter/index.ts
+++ b/packages/hooks/src/useRangeFilter/index.ts
@@ -30,7 +30,7 @@ function useRangeFilter(name: string) {
   useEffect(() => {
     // Ignore the componentDidMount trigger, only call after the query was changed
     if (isAggregate && prevQuery.current !== null) {
-      filter.reset(false);
+      filter.aggregateReset(false);
     }
   }, [query]);
 


### PR DESCRIPTION
Previously, changing query will remove range filters from the search request via the `reset` function but the update in https://github.com/sajari/sdk-react/commit/66761119165a94ec3a779e0c651ecfb77406dcba was causing the range filters to appear in the request so the return values of aggregate min and max are incorrect.