### PR TITLE
fix: modal footer being overlapped by Safari bottom bar

### DIFF
--- a/.changeset/grumpy-paws-return.md
+++ b/.changeset/grumpy-paws-return.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix the footer of Modal being covered by the bottom bar of Safari.

--- a/packages/components/src/Modal/styles.ts
+++ b/packages/components/src/Modal/styles.ts
@@ -128,7 +128,7 @@ export function useModalStyles(props: ModalProps) {
       center ? tw`m-auto` : tw`mx-auto`,
       fullWidth ? tw`max-w-full` : sizeStyle,
       fullWidth ? tw`rounded-none` : tw`rounded-xl`,
-      fullHeight ? tw`h-screen` : tw`max-h-(screen-20)`,
+      fullHeight ? tw`h-full` : tw`max-h-(screen-20)`,
     ],
   };
 


### PR DESCRIPTION
Without the fix, the pagination is overlapped by the bottom bar of Safari

![image](https://user-images.githubusercontent.com/12707960/118641592-8a069800-b804-11eb-9efe-42dc5568188e.png)
