### PR TITLE
Reposition dropdown as soon as input receive focus

### DIFF
--- a/.changeset/late-bugs-brake.md
+++ b/.changeset/late-bugs-brake.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix dropdown flicker/jumping into position when render

--- a/packages/components/src/Combobox/components/Dropdown/index.tsx
+++ b/packages/components/src/Combobox/components/Dropdown/index.tsx
@@ -89,8 +89,13 @@ const Dropdown = () => {
         modifiers: [{ name: 'flip', enabled: false }],
       });
     }
+    function reposition() {
+      instance?.forceUpdate();
+    }
+    inputElement?.current?.addEventListener('focus', reposition);
     return () => {
       instance?.destroy();
+      inputElement?.current?.removeEventListener('focus', reposition);
     };
   }, [shown, inputElement, ref.current]);
 


### PR DESCRIPTION
## The problem
Notice the flickering
![Screen Recording 2021-06-07 at 15 02 17](https://user-images.githubusercontent.com/25856620/120981531-f3454f80-c7a1-11eb-87c2-219cf4df061a.gif)

## The solution
Call popper's `forceUpdate` as soon as the input receive focus