### PR TITLE
feat: variant option

### DIFF
--- a/.changeset/soft-garlics-invite.md
+++ b/.changeset/soft-garlics-invite.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': minor
+'@sajari/react-hooks': minor
+'@sajari/react-search-ui': minor
+---
+
+Show product's variant images if any

--- a/docs/pages/search-ui/results.mdx
+++ b/docs/pages/search-ui/results.mdx
@@ -86,6 +86,60 @@ function Example() {
 }
 ```
 
+### Product variant images
+
+If your collection's products have variants (e.g Shopify), you can map `image` and `price` to an be an array of image urls and prices, respectively.
+
+```jsx
+function Example() {
+  const pipeline = new Pipeline(
+    {
+      account: '1617265323067869891',
+      collection: 'tuandaosajari',
+      endpoint: '//jsonapi-au-staging-valkyrie2.sajari.com',
+    },
+    'query',
+  );
+
+  const fields = new FieldDictionary({
+    url: '/products/${handle}',
+    subtitle: 'vendor',
+    description: 'body_html',
+    image: (values) => {
+      const variantImages = values.variant_ids.map((_, i) => {
+        const variantImageId = values.variant_image_ids[i];
+        const variantImageIndex = values.image_ids.findIndex((ii) => ii === variantImageId);
+        const variantImageUrl = values.image_urls[variantImageIndex];
+
+        return variantImageUrl;
+      });
+
+      return [values.image_urls[0], ...variantImages];
+    },
+    price: (values) => {
+      return [values.variant_prices, ...values.variant_prices];
+    },
+    originalPrice: 'variant_compare_at_prices',
+  });
+
+  return (
+    <SearchProvider
+      search={{
+        pipeline,
+        fields,
+        variables: new Variables({ q: 'double pocket skirt' }),
+      }}
+      searchOnLoad
+    >
+      <div className="flex flex-col items-center space-y-4">
+        <ViewType />
+        <Results />
+      </div>
+    </SearchProvider>
+  );
+}
+```
+
 ## Props
 
 | Name                | Type                                         | Default   | Description                                                                                                                     |

--- a/docs/pages/search-ui/results.mdx
+++ b/docs/pages/search-ui/results.mdx
@@ -86,60 +86,6 @@ function Example() {
 }
 ```
 
-### Product variant images
-
-If your collection's products have variants (e.g Shopify), you can map `image` and `price` to an be an array of image urls and prices, respectively.
-
-```jsx
-function Example() {
-  const pipeline = new Pipeline(
-    {
-      account: '1617265323067869891',
-      collection: 'tuandaosajari',
-      endpoint: '//jsonapi-au-staging-valkyrie2.sajari.com',
-    },
-    'query',
-  );
-
-  const fields = new FieldDictionary({
-    url: '/products/${handle}',
-    subtitle: 'vendor',
-    description: 'body_html',
-    image: (values) => {
-      const variantImages = values.variant_ids.map((_, i) => {
-        const variantImageId = values.variant_image_ids[i];
-        const variantImageIndex = values.image_ids.findIndex((ii) => ii === variantImageId);
-        const variantImageUrl = values.image_urls[variantImageIndex];
-
-        return variantImageUrl;
-      });
-
-      return [values.image_urls[0], ...variantImages];
-    },
-    price: (values) => {
-      return [values.variant_prices, ...values.variant_prices];
-    },
-    originalPrice: 'variant_compare_at_prices',
-  });
-
-  return (
-    <SearchProvider
-      search={{
-        pipeline,
-        fields,
-        variables: new Variables({ q: 'double pocket skirt' }),
-      }}
-      searchOnLoad
-    >
-      <div className="flex flex-col items-center space-y-4">
-        <ViewType />
-        <Results />
-      </div>
-    </SearchProvider>
-  );
-}
-```
-
 ## Props
 
 | Name                | Type                                         | Default   | Description                                                                                                                     |

--- a/packages/components/src/Image/styles.ts
+++ b/packages/components/src/Image/styles.ts
@@ -45,7 +45,6 @@ function useObjectPosition(objectPosition: ImageProps['objectPosition']) {
     case 'right-bottom':
       return tw`object-right-bottom`;
     case 'center':
-      return tw`object-center`;
     default:
       return tw`object-center`;
   }

--- a/packages/components/src/Image/styles.ts
+++ b/packages/components/src/Image/styles.ts
@@ -26,22 +26,49 @@ function useObjectFit(objectFit: ImageProps['objectFit'], isSecondImage = false)
   }
 }
 
+function useObjectPosition(objectPosition: ImageProps['objectPosition']) {
+  switch (objectPosition) {
+    case 'top':
+      return tw`object-top`;
+    case 'bottom':
+      return tw`object-bottom`;
+    case 'left':
+      return tw`object-left`;
+    case 'right':
+      return tw`object-right`;
+    case 'left-top':
+      return tw`object-left-top`;
+    case 'left-bottom':
+      return tw`object-left-bottom`;
+    case 'right-top':
+      return tw`object-right-top`;
+    case 'right-bottom':
+      return tw`object-right-bottom`;
+    case 'center':
+      return tw`object-center`;
+    default:
+      return tw`object-center`;
+  }
+}
+
 export function useImageStyles(props: ImageProps & { hover: boolean }) {
   const hasLoaded = useHasImageLoaded(props);
-  const { hover, objectFit } = props;
+  const { hover, objectFit, objectPosition } = props;
   const styles = {
-    container: [tw`relative rounded-md`, !hasLoaded ? tw`bg-gray-100` : ''],
+    container: [tw`relative rounded-sm`, !hasLoaded ? tw`bg-gray-100` : ''],
     image: [
       tw`transition-opacity duration-200 ease-in`,
       hasLoaded && !hover ? tw`opacity-100` : tw`opacity-0`,
       { borderRadius: 'inherit' },
       useObjectFit(objectFit),
+      useObjectPosition(objectPosition),
     ],
     secondImage: [
       tw`absolute top-0 left-0 object-cover w-full h-full transition-opacity duration-200 ease-in`,
       hasLoaded && hover ? tw`opacity-100` : tw`opacity-0`,
       { borderRadius: 'inherit' },
       useObjectFit(objectFit, true),
+      useObjectPosition(objectPosition),
     ],
   };
 

--- a/packages/components/src/Image/types.ts
+++ b/packages/components/src/Image/types.ts
@@ -20,6 +20,17 @@ interface Props extends BoxProps {
   aspectRatio?: AspectRatioProps['ratio'];
   /** Handy for use with the aspectRatio option */
   objectFit?: 'contain' | 'cover' | 'fill' | 'scale-down' | 'none';
+  /** Handy for use with the aspectRatio option */
+  objectPosition?:
+    | 'left'
+    | 'right'
+    | 'bottom'
+    | 'top'
+    | 'left-top'
+    | 'left-bottom'
+    | 'right-top'
+    | 'right-bottom'
+    | 'center';
   /** The classname for  AspectRatio container wrapper */
   containerClassName?: string;
   /** The image sources, pass in an array to display the second image on hover */

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -173,8 +173,7 @@ const Result = React.memo(
           css={styles.previewImagesContainer}
           aria-label={t('previewImagesContainer', { product: decodeHTML(title) })}
         >
-          {image &&
-            isArray(image) &&
+          {isArray(image) &&
             image.map((url, i) => {
               const setActive = getSetActive(url, i);
               return (

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -11,6 +11,7 @@ import {
   isValidURL,
 } from '@sajari/react-sdk-utils';
 import React, { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../../../ContextProvider';
 import { useClickTracking } from '../../../hooks';
@@ -38,6 +39,7 @@ const Result = React.memo(
       showImage: showImageProp = true,
       ...rest
     } = props;
+    const { t } = useTranslation('result');
     const { currency, language, ratingMax, tracking } = useSearchUIContext();
     const { href, onClick } = useClickTracking({ token, tracking, values, onClick: onClickProp });
     const { title, description, subtitle, image, price, originalPrice } = values;
@@ -167,7 +169,10 @@ const Result = React.memo(
         [],
       );
       return (
-        <Box css={styles.previewImagesContainer} aria-label={`${decodeHTML(title)}'s images`}>
+        <Box
+          css={styles.previewImagesContainer}
+          aria-label={t('previewImagesContainer', { product: decodeHTML(title) })}
+        >
           {image &&
             isArray(image) &&
             image.map((url, i) => {
@@ -177,7 +182,7 @@ const Result = React.memo(
                   role="img"
                   key={`product-image-${url}`}
                   css={styles.previewImageContainer}
-                  aria-label={`${decodeHTML(title)} image number ${i + 1}`}
+                  aria-label={t('previewImage', { product: decodeHTML(title), number: i + 1 })}
                   onMouseEnter={setActive}
                   tabIndex={0}
                   onKeyPress={(e) => {

--- a/packages/search-ui/src/Results/components/Result/styles.ts
+++ b/packages/search-ui/src/Results/components/Result/styles.ts
@@ -12,9 +12,9 @@ export default function useResultStyles(props: UseResultStylesParams) {
 
   const styles = inferStylesObjectKeys({
     container: [],
+    wrapper: [tw`flex flex-col`],
     imageContainer: [],
-    image: [tw`rounded-md`],
-    content: [tw`flex-1 min-w-0`],
+    content: [tw`min-w-0`],
     header: [tw`flex items-start justify-between`],
     title: [tw`font-medium`],
     subtitle: [tw`text-xs text-gray-400`],
@@ -23,17 +23,24 @@ export default function useResultStyles(props: UseResultStylesParams) {
     priceContainer: [],
     price: [isOnSale ? tw`font-medium text-red-500` : ''],
     originalPrice: [tw`text-xs text-gray-400 line-through`],
+    previewImagesContainer: [tw`flex flex-wrap gap-2 w-full my-2`],
+    previewImageContainer: [
+      tw`w-9 h-9 outline-none rounded-md p-0.5 border-2 border-transparent focus:border-indigo-400`,
+    ],
   });
 
   switch (appearance) {
     case 'grid':
-      styles.container.push(tw`text-center`);
-      styles.imageContainer.push(tw`block mb-4`);
+      styles.container.push(tw`text-center flex flex-col`);
+      styles.title.push(tw`mt-2`);
+      styles.content.push(tw`mt-auto`);
+      styles.imageContainer.push(tw`block`);
       styles.priceContainer.push(tw`flex items-baseline justify-center space-x-1`);
       break;
 
     default:
     case 'list':
+      styles.content.push(tw`flex-1`);
       styles.container.push(tw`flex items-center w-full`);
       styles.imageContainer.push(tw`w-24 mr-6`);
       styles.priceContainer.push(tw`text-right`);

--- a/packages/search-ui/src/Results/components/Result/styles.ts
+++ b/packages/search-ui/src/Results/components/Result/styles.ts
@@ -12,7 +12,7 @@ export default function useResultStyles(props: UseResultStylesParams) {
 
   const styles = inferStylesObjectKeys({
     container: [],
-    wrapper: [tw`flex flex-col`],
+    wrapper: [tw`flex flex-col mb-4`],
     imageContainer: [],
     content: [tw`min-w-0`],
     header: [tw`flex items-start justify-between`],
@@ -33,7 +33,6 @@ export default function useResultStyles(props: UseResultStylesParams) {
     case 'grid':
       styles.container.push(tw`text-center flex flex-col`);
       styles.title.push(tw`mt-2`);
-      styles.content.push(tw`mt-auto`);
       styles.imageContainer.push(tw`block`);
       styles.priceContainer.push(tw`flex items-baseline justify-center space-x-1`);
       break;

--- a/packages/search-ui/src/Results/components/Result/styles.ts
+++ b/packages/search-ui/src/Results/components/Result/styles.ts
@@ -23,7 +23,7 @@ export default function useResultStyles(props: UseResultStylesParams) {
     priceContainer: [],
     price: [isOnSale ? tw`font-medium text-red-500` : ''],
     originalPrice: [tw`text-xs text-gray-400 line-through`],
-    previewImagesContainer: [tw`flex flex-wrap gap-2 w-full my-2`],
+    previewImagesContainer: [tw`flex flex-wrap gap-1 w-full my-2`],
     previewImageContainer: [
       tw`w-9 h-9 outline-none rounded-md p-0.5 border-2 border-transparent focus:border-indigo-400`,
     ],
@@ -31,6 +31,7 @@ export default function useResultStyles(props: UseResultStylesParams) {
 
   switch (appearance) {
     case 'grid':
+      styles.previewImagesContainer.push(tw`justify-center max-w-fit-content mx-auto`);
       styles.container.push(tw`text-center flex flex-col`);
       styles.title.push(tw`mt-2`);
       styles.imageContainer.push(tw`block`);

--- a/packages/search-ui/src/i18n/locale/en.ts
+++ b/packages/search-ui/src/i18n/locale/en.ts
@@ -41,6 +41,10 @@ export default {
       body: 'No matches were found for "{{query}}".',
     },
   },
+  result: {
+    previewImagesContainer: "{{product}}'s images",
+    previewImage: '{{product}} image number {{number}}',
+  },
   sorting: {
     label: 'Sort',
   },

--- a/packages/utils/src/styles/tailwind.config.js
+++ b/packages/utils/src/styles/tailwind.config.js
@@ -40,6 +40,7 @@ export default {
         inherit: 'inherit',
       },
       maxWidth: {
+        'fit-content': 'fit-content',
         '7xl': '80rem',
         'screen-2xl': '1536px',
       },


### PR DESCRIPTION
Add ability to show a product's variant images

It’s worth noting that since this new feature is added it will collide with the current image hover feature. To resolve that, only products that have variant images to show will no longer change on hover.