### PR TITLE
fix: margin of menu option is overridden by external CSS

### DIFF
--- a/.changeset/fresh-coins-think.md
+++ b/.changeset/fresh-coins-think.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix margin of menu option is overridden by external CSS.

--- a/packages/components/src/hooks/useDropdownItemStyles.ts
+++ b/packages/components/src/hooks/useDropdownItemStyles.ts
@@ -11,7 +11,7 @@ export function useDropdownItemStyles(params: UseDropdownItemStylesParams) {
 
   const styles = inferStylesObjectKeys({
     root: [
-      tw`flex items-center w-auto px-2 py-1 leading-5 text-left transition-all duration-75 rounded cursor-pointer`,
+      tw`flex items-center w-auto px-2 py-1 leading-5 text-left transition-all duration-75 rounded cursor-pointer m-0`,
     ],
     label: [tw`pl-4 ml-auto text-xs text-gray-400`],
   });


### PR DESCRIPTION
Fix margin of the menu option is overridden by external CSS. The issue is recorded on https://www.sajari.com/

![image](https://user-images.githubusercontent.com/12707960/121878750-44bb8480-cd36-11eb-9f97-9253f0a77938.png)
