### PR TITLE
chore: remove redundant message type

### DIFF
--- a/.changeset/five-doors-judge.md
+++ b/.changeset/five-doors-judge.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Remove redundant variant of Message component

--- a/packages/search-ui/src/Results/components/Message/index.tsx
+++ b/packages/search-ui/src/Results/components/Message/index.tsx
@@ -19,20 +19,6 @@ const Message = (props: MessageProps) => {
           </Box>
         );
 
-      case 'error':
-        return (
-          <React.Fragment>
-            <Heading size="3xl" css={styles.errorHeading} disableDefaultStyles={disableDefaultStyles}>
-              {title}
-            </Heading>
-            {body && (
-              <Text css={styles.errorText} disableDefaultStyles={disableDefaultStyles}>
-                {body}
-              </Text>
-            )}
-          </React.Fragment>
-        );
-
       default:
       case 'default':
         return (

--- a/packages/search-ui/src/Results/components/Message/styles.ts
+++ b/packages/search-ui/src/Results/components/Message/styles.ts
@@ -7,8 +7,6 @@ export default function useMessageStyles() {
     loadingWrapper: [tw`text-gray-500`],
     loadingSpinner: [tw`inline-block w-6 h-6`],
     loadingText: [tw`mt-3`],
-    errorHeading: [tw`text-red-500`],
-    errorText: [tw`text-gray-500`],
     defaultText: [tw`text-gray-500`],
   };
 

--- a/packages/search-ui/src/Results/components/Message/types.ts
+++ b/packages/search-ui/src/Results/components/Message/types.ts
@@ -4,5 +4,5 @@ export interface MessageProps extends BoxProps {
   title: string;
   body?: string;
   loading?: boolean;
-  appearance?: 'default' | 'loading' | 'error';
+  appearance?: 'default' | 'loading';
 }


### PR DESCRIPTION
## Why

The `error` appearance of the `Message` component is internal is not used anywhere and won't likely be used in the future so we could save some bytes off the bundle by removing it.