### PR TITLE
fix: capitalize-first-letter not work properly if text input is all uppercase

### DIFF
--- a/.changeset/loud-points-double.md
+++ b/.changeset/loud-points-double.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': patch
+'sajari-sdk-docs': patch
+---
+
+Fix `capitalize-first-letter` option of textTransform won't work if the text input is all uppercasce.

--- a/packages/search-ui/src/Filter/test/utils.test.ts
+++ b/packages/search-ui/src/Filter/test/utils.test.ts
@@ -1,7 +1,7 @@
 import { FilterItem } from '@sajari/react-hooks';
 
 import { TextTransform } from '../types';
-import { capitalize, formatLabel, pinItems } from '../utils';
+import { capitalize, capitalizeFirstLetter, formatLabel, pinItems } from '../utils';
 
 describe('pinItems', () => {
   test.each([
@@ -111,5 +111,20 @@ describe('capitalize', () => {
     ['crimsonred', 'Crimsonred'],
   ])('capitalize(%s)', (input, output) => {
     expect(capitalize(input)).toBe(output);
+  });
+});
+
+describe('capitalize first letter', () => {
+  test.each([
+    ['', ''],
+    ['red', 'Red'],
+    ['picton Blue', 'Picton blue'],
+    ['crimsonred', 'Crimsonred'],
+    ['CAR & GPS', 'Car & gps'],
+    ['mEssy', 'Messy'],
+    ['caPitalIZE fiRST letter', 'Capitalize first letter'],
+    ['random value', 'Random value'],
+  ])('capitalize first value(%s)', (input, output) => {
+    expect(capitalizeFirstLetter(input)).toBe(output);
   });
 });

--- a/packages/search-ui/src/Filter/utils.ts
+++ b/packages/search-ui/src/Filter/utils.ts
@@ -39,6 +39,15 @@ export function capitalize(value: string): string {
 }
 
 /**
+ * Capitalize first letter a string value
+ * @param {string} the string to be capitalized first value
+ * @returns {string} the capitalized first letter value
+ */
+export function capitalizeFirstLetter(value: string): string {
+  return (value[0] || '').toLocaleUpperCase() + value.toLocaleLowerCase().slice(1);
+}
+
+/**
  * Format a value to be presented in the UI
  * @param input - the value to format
  * @param params - formatting options
@@ -71,7 +80,7 @@ export function formatLabel(input: string, params: FormatValueParams) {
         case 'capitalize':
           return capitalize(input);
         case 'capitalize-first-letter':
-          return (input[0] || '').toLocaleUpperCase() + input.slice(1);
+          return capitalizeFirstLetter(input);
         case 'normal-case':
         default:
           return input;


### PR DESCRIPTION
Fix `capitalize-first-letter` option of textTransform won't work if the text input is all uppercasce.