### PR TITLE
fix: capitalize util works incorrectly

### DIFF
--- a/.changeset/healthy-frogs-roll.md
+++ b/.changeset/healthy-frogs-roll.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': patch
+'sajari-sdk-docs': patch
+---
+
+Fix `capitalize` utility works incorrectly, where a string in uppercase letters is not converted to a capitalized output. For example, `hELLO` is converted to `HELLO` instead of `Hello`.

--- a/packages/search-ui/src/Filter/test/utils.test.ts
+++ b/packages/search-ui/src/Filter/test/utils.test.ts
@@ -92,7 +92,7 @@ describe('formatLabel', () => {
     ['text', 'normal-case', 'default', 'text'],
     ['Car Electronics & GPS', 'uppercase', 'default', 'CAR ELECTRONICS & GPS'],
     ['Car Electronics & GPS', 'lowercase', 'default', 'car electronics & gps'],
-    ['Car Electronics & GPS', 'capitalize', 'default', 'Car Electronics & GPS'],
+    ['Car Electronics & GPS', 'capitalize', 'default', 'Car Electronics & Gps'],
 
     ['> 200', 'normal-case', 'price', 'rangeOver'],
   ])(
@@ -109,6 +109,12 @@ describe('capitalize', () => {
     ['red', 'Red'],
     ['picton Blue', 'Picton Blue'],
     ['crimsonred', 'Crimsonred'],
+    ['CAR & GPS', 'Car & Gps'],
+    ['mEssy', 'Messy'],
+    ['caPitalIZE all words', 'Capitalize All Words'],
+    ['random value', 'Random Value'],
+    ['HELLO world', 'Hello World'],
+    ['one two', 'One Two'],
   ])('capitalize(%s)', (input, output) => {
     expect(capitalize(input)).toBe(output);
   });

--- a/packages/search-ui/src/Filter/utils.ts
+++ b/packages/search-ui/src/Filter/utils.ts
@@ -35,7 +35,7 @@ interface FormatValueParams {
  * @returns {string} the capitalized value
  */
 export function capitalize(value: string): string {
-  return value.replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase());
+  return value.toLocaleLowerCase().replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase());
 }
 
 /**

--- a/packages/search-ui/src/Filter/utils.ts
+++ b/packages/search-ui/src/Filter/utils.ts
@@ -35,7 +35,7 @@ interface FormatValueParams {
  * @returns {string} the capitalized value
  */
 export function capitalize(value: string): string {
-  return value.toLocaleLowerCase().replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase());
+  return value.toLocaleLowerCase().replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toLocaleUpperCase());
 }
 
 /**


### PR DESCRIPTION
Fix `capitalize` utility works incorrectly, where a string in uppercase letters is not converted to a capitalized output. For example, `hELLO` is converted to `HELLO` instead of `Hello`.