### PR TITLE
fix: custom config not working

### DIFF
--- a/.changeset/perfect-jokes-marry.md
+++ b/.changeset/perfect-jokes-marry.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix passing a custom `config` object doesn't work.

--- a/packages/hooks/src/ContextProvider/index.tsx
+++ b/packages/hooks/src/ContextProvider/index.tsx
@@ -180,7 +180,7 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
         pipeline.search(variables.get());
       }, 50);
     },
-    [],
+    [autocompleteState.config, searchState.config],
   );
 
   useEffect(() => {

--- a/packages/hooks/src/useQuery/index.ts
+++ b/packages/hooks/src/useQuery/index.ts
@@ -4,12 +4,12 @@ import { useContext } from '../ContextProvider';
 
 function useQuery() {
   const {
-    search: { search, variables, query },
+    search: { search, variables, query, config },
   } = useContext();
 
   const setQuery = React.useCallback(
     (q: string) => {
-      variables.set({ q });
+      variables.set({ [config.qParam]: q });
       search(q);
     },
     [search, variables],


### PR DESCRIPTION
Fix passing a custom `config` object doesn't work.