### PR TITLE
fix: update useRangeFilter reset method

### DIFF
--- a/.changeset/poor-papayas-sing.md
+++ b/.changeset/poor-papayas-sing.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-hooks': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Update `useRangeFilter` reset method to follow the change of `RangeFilterBuilder` reset as setting the filter to `null` is equivalent to setting the filter to `[min, max]`. Also, remove the redundant `aggregateReset`.

--- a/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
@@ -178,22 +178,6 @@ export default class RangeFilterBuilder {
     }
   }
 
-  /**
-   * Set null to the current range to exclude the filter from the search request
-   * so the the backend can aggregate the maximum range of [min, max] for a query
-   */
-  public aggregateReset(emitEvent = true) {
-    if (this.frozen && !this.isAggregate) {
-      return;
-    }
-
-    this.range = null;
-
-    if (emitEvent) {
-      this.emitRangeUpdated();
-    }
-  }
-
   public format(value: Range) {
     return this.formatter(value);
   }

--- a/packages/hooks/src/useRangeFilter/index.ts
+++ b/packages/hooks/src/useRangeFilter/index.ts
@@ -30,7 +30,7 @@ function useRangeFilter(name: string) {
   useEffect(() => {
     // Ignore the componentDidMount trigger, only call after the query was changed
     if (isAggregate && prevQuery.current !== null) {
-      filter.aggregateReset(false);
+      filter.reset(false);
     }
   }, [query]);
 
@@ -60,11 +60,7 @@ function useRangeFilter(name: string) {
   }, [range, min, max]);
 
   const reset = () => {
-    if (isAggregate) {
-      filter.set([...filter.getMinMax()] as Range);
-    } else {
-      filter.reset();
-    }
+    filter.reset();
   };
 
   useEffect(() => {


### PR DESCRIPTION
Update `useRangeFilter` reset method to follow the change of `RangeFilterBuilder` reset as setting the filter to `null` is equivalent to setting the filter to `[min, max]`. Also, remove the redundant `aggregateReset`.