### PR TITLE
fix: results are not updated after a re-render

### DIFF
--- a/.changeset/dry-flowers-raise.md
+++ b/.changeset/dry-flowers-raise.md
@@ -1,0 +1,6 @@
+---
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix the result image disappears after a re-render. It will happen if the response doesn't include a unique id for each entry.

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -92,7 +92,7 @@ const Results = (props: ResultsProps) => {
           onClick={handleResultClicked}
           token={token}
           // eslint-disable-next-line no-underscore-dangle
-          key={values._id ?? i}
+          key={values._id ?? values.url ?? i}
           values={values}
           appearance={appearance}
           forceImage={hasImages}


### PR DESCRIPTION
Fix the result image disappears after a re-render. It will happen if the response doesn't include a unique id for each entry.