### PR TITLE
fix: missing _id in the response

### DIFF
--- a/.changeset/tricky-seahorses-hammer.md
+++ b/.changeset/tricky-seahorses-hammer.md
@@ -1,0 +1,7 @@
+---
+'sajari-sdk-docs': patch
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+Include `fields:''` in the body request to always expect `_id` to be in the response. It's necessary, otherwise, it could break the re-render process of Results where the `key` relies on the `_id`.

--- a/docs/pages/classes/config.mdx
+++ b/docs/pages/classes/config.mdx
@@ -23,4 +23,5 @@ import { Config } from '@sajari/react-hooks';
 | `qSuggestionsParam`   | `'q.suggestions'`  | The key for dictionary of name -> filter pairs.   |
 | `resultsPerPageParam` | `'resultsPerPage'` | The key for how many results to display per page. |
 | `pageParam`           | `'page'`           | The key for which page to display.                |
+| `fieldsParam`         | `'fields'`         | The key for what fields to show in the response.  |
 | `maxSuggestions`      | `10`               |                                                   |

--- a/docs/pages/classes/variables.mdx
+++ b/docs/pages/classes/variables.mdx
@@ -22,11 +22,12 @@ The constructor will accept a single object with any properties. The proprties w
 
 Value types can be `string | string[] | number | boolean | () => string`
 
-| Name             | Default     | Description                           |
-| ---------------- | ----------- | ------------------------------------- |
-| `q`              |             | The search query.                     |
-| `q.override`     |             |                                       |
-| `q.suggestions`  |             | Dictionary of name -> filter pairs.   |
-| `filter`         | `_id != ""` | Default filter to apply.              |
-| `resultsPerPage` | `15`        | How many results to display per page. |
-| `page`           | `1`         | Which page to display.                |
+| Name             | Default     | Description                                                       |
+| ---------------- | ----------- | ----------------------------------------------------------------- |
+| `q`              |             | The search query.                                                 |
+| `q.override`     |             |                                                                   |
+| `q.suggestions`  |             | Dictionary of name -> filter pairs.                               |
+| `filter`         | `_id != ""` | Default filter to apply.                                          |
+| `resultsPerPage` | `15`        | How many results to display per page.                             |
+| `page`           | `1`         | Which page to display.                                            |
+| `fields`         | `''`        | What fields are shown in the response. Use "" to show all fields. |

--- a/packages/hooks/src/ContextProvider/Config.ts
+++ b/packages/hooks/src/ContextProvider/Config.ts
@@ -5,6 +5,7 @@ export interface Config {
   resultsPerPageParam: string;
   pageParam: string;
   maxSuggestions: number;
+  fieldsParam: string;
 }
 
 export const defaultConfig: Config = {
@@ -14,4 +15,5 @@ export const defaultConfig: Config = {
   resultsPerPageParam: 'resultsPerPage',
   pageParam: 'page',
   maxSuggestions: 10,
+  fieldsParam: 'fields',
 };

--- a/packages/hooks/src/ContextProvider/controllers/Variables.ts
+++ b/packages/hooks/src/ContextProvider/controllers/Variables.ts
@@ -27,6 +27,7 @@ export class Variables {
       Object.entries({
         [defaultConfig.qParam]: '',
         [defaultConfig.resultsPerPageParam]: 15,
+        [defaultConfig.fieldsParam]: '',
         ...variables,
       }),
     );


### PR DESCRIPTION
Include `fields:''` in the body request to always expect `_id` to be in the response. It's necessary, otherwise, it could break the re-render process of Results where the `key` relies on the `_id`.