### PR TITLE
fix: modal footer gets hidden on ipad

### DIFF
--- a/.changeset/afraid-rabbits-compare.md
+++ b/.changeset/afraid-rabbits-compare.md
@@ -1,0 +1,8 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-sdk-utils': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix the issue when the footer of the modal gets hidden on iPad. It was because we used `vh` to limit the max height of the modal content but on mobile browsers, the bottom bar is not part the the `100vh` height so the bottom UI will be cut off when the address bar is visible. For more details, see https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html.

--- a/packages/components/src/Modal/styles.ts
+++ b/packages/components/src/Modal/styles.ts
@@ -128,7 +128,7 @@ export function useModalStyles(props: ModalProps) {
       center ? tw`m-auto` : tw`mx-auto`,
       fullWidth ? tw`max-w-full` : sizeStyle,
       fullWidth ? tw`rounded-none` : tw`rounded-xl`,
-      fullHeight ? tw`h-full` : tw`max-h-(screen-20)`,
+      fullHeight ? tw`h-full` : tw`max-h-(full-12)`,
     ],
   };
 

--- a/packages/utils/src/styles/tailwind.config.js
+++ b/packages/utils/src/styles/tailwind.config.js
@@ -52,6 +52,7 @@ export default {
         '(screen-12)': 'calc(100vh - 3rem)',
         '(screen-16)': 'calc(100vh - 4rem)',
         '(screen-20)': 'calc(100vh - 5rem)',
+        '(full-12)': 'calc(100% - 3rem)',
       },
     },
   },


### PR DESCRIPTION
Fix the issue when the footer of the modal gets hidden on iPad. It was because we used `vh` to limit the max height of the modal content, but on mobile browsers, the bottom bar is not part the the `100vh` height so the bottom UI will be cut off when the address bar is visible. For more details, see https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html.