### PR TITLE
feat: support custom clicktracking url so we can test in non-prod environments

### DIFF
--- a/.changeset/cyan-foxes-check.md
+++ b/.changeset/cyan-foxes-check.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-hooks': minor
+'@sajari/react-search-ui': patch
+'@sajari/react-sdk-utils': patch
+---
+
+feat: support custom clicktracking url so we can test in non-prod environments

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@sajari/react-sdk-utils": "^1.3.15",
-    "@sajari/sdk-js": "^2.0.0-rc.2",
+    "@sajari/sdk-js": "^2.0.2",
     "js-cookie": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/hooks/src/ContextProvider/controllers/Pipeline.test.ts
+++ b/packages/hooks/src/ContextProvider/controllers/Pipeline.test.ts
@@ -1,7 +1,7 @@
 import { waitFor } from '@testing-library/react';
 
 import { EVENT_RESPONSE_UPDATED, EVENT_RESULT_CLICKED } from '../events';
-import { pipeline1 } from './fixtures/Pipeline';
+import { customConfigPipeline, pipeline1 } from './fixtures/Pipeline';
 import { Pipeline } from './Pipeline';
 import { ClickTracking } from './tracking';
 
@@ -41,5 +41,19 @@ describe('Pipeline', () => {
 
     expect(onResultClick).toHaveBeenCalled();
     expect(onResultClick.mock.results[0].value).toEqual(data);
+  });
+
+  it('should set a custom click token url', () => {
+    const clickTokenURL = 'https://example.com';
+    const pipeline = new Pipeline({ ...pipeline1, clickTokenURL }, pipeline1.name, new ClickTracking());
+
+    expect(pipeline.getClient().config.clickTokenURL).toEqual(clickTokenURL);
+  });
+
+  it('should set a custom user agent', () => {
+    const userAgent = 'test user agent';
+    const pipeline = new Pipeline({ ...pipeline1, userAgent }, pipeline1.name, new ClickTracking());
+
+    expect(pipeline.getClient().config.userAgent).toEqual(userAgent);
   });
 });

--- a/packages/hooks/src/ContextProvider/controllers/fixtures/Pipeline.ts
+++ b/packages/hooks/src/ContextProvider/controllers/fixtures/Pipeline.ts
@@ -4,3 +4,9 @@ export const pipeline1 = {
   endpoint: 'test.endpoint',
   name: 'pipeline.name',
 };
+
+export const customConfigPipeline = {
+  ...pipeline1,
+  clickTokenURL: 'https://example.com',
+  userAgent: 'test-user-agent',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4332,10 +4332,10 @@
     eslint-config-airbnb-typescript "^12.0.0"
     eslint-config-prettier "^7.1.0"
 
-"@sajari/sdk-js@^2.0.0-rc.2":
-  version "2.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@sajari/sdk-js/-/sdk-js-2.0.0-rc.2.tgz#082fcee53747ac084d95e7347f73c09024fc9649"
-  integrity sha512-dua+9SfeQ0Drcj/wKYe4SV5HZ7B9TjvMD+0fdLx8hDhFZ78VTIdDofvxgdghJdPY2IBCVyQl6ScRqQb1zqDQlw==
+"@sajari/sdk-js@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@sajari/sdk-js/-/sdk-js-2.0.2.tgz#fa0613c2cbccbf0899f19fbdc3af6018576c1de7"
+  integrity sha512-KmmahNKx7LkSQrSlNEmU+EqLiV7PT1WmHOd4fjvSWkcSlI/WLUA7RJPkmosrE6KuIpV2Ah366e1G6DiLH6Yv6g==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"


### PR DESCRIPTION
Gives the ability pass a custom click token url for use in staging environments. Allows end to end testing of clicktracking.