### PR TITLE
feat: add support for features of Result component to result template

### DIFF
--- a/.changeset/rotten-candles-attack.md
+++ b/.changeset/rotten-candles-attack.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': minor
+'@sajari/react-sdk-utils': minor
+---
+
+Add support for features of Result component to result template

--- a/.changeset/rotten-candles-attack.md
+++ b/.changeset/rotten-candles-attack.md
@@ -1,6 +1,7 @@
 ---
 '@sajari/react-search-ui': minor
 '@sajari/react-sdk-utils': minor
+'@sajari/react-components': patch
 ---
 
 Add support for features of Result component to result template

--- a/docs/pages/search-ui/results.mdx
+++ b/docs/pages/search-ui/results.mdx
@@ -161,10 +161,13 @@ function Example() {
 
 <a href="{{url}}">
   <article class="relative p-3 rounded-md border border-gray-200 shadow flex flex-col h-full">
-     <div class="relative">
-       <div class="product-image">
-         <img data-sj-first-image class="absolute top-0 left-0 h-full w-full object-contain object-center" src="{{image}}" />
+     <div>
+       <div class="relative">
+         <div class="product-image">
+           <img data-sj-first-image class="absolute top-0 left-0 h-full w-full object-contain object-center" src="{{image}}" />
+         </div>
        </div>
+       <div data-sj-product-images-container></div>
      </div>
      <p class="font-medium text-gray-700 mt-4">{{title}}</p>
      <p class="text-xs text-gray-400 mt-1 mb-8">{{subtitle}}</p>

--- a/docs/pages/search-ui/results.mdx
+++ b/docs/pages/search-ui/results.mdx
@@ -163,7 +163,7 @@ function Example() {
   <article class="relative p-3 rounded-md border border-gray-200 shadow flex flex-col h-full">
      <div class="relative">
        <div class="product-image">
-         <img class="absolute top-0 left-0 h-full w-full object-contain object-center" src="{{image}}" />
+         <img data-sj-first-image class="absolute top-0 left-0 h-full w-full object-contain object-center" src="{{image}}" />
        </div>
      </div>
      <p class="font-medium text-gray-700 mt-4">{{title}}</p>

--- a/docs/pages/search-ui/results.mdx
+++ b/docs/pages/search-ui/results.mdx
@@ -153,6 +153,7 @@ function Example() {
       collection: 'bestbuy',
     },
     'query',
+    new ClickTracking(),
   );
 
   const template = {

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -17,7 +17,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../../../ContextProvider';
-import { applyClickTracking, applyPosNegTracking } from '../../../utils';
 import { useProductStatuses } from '../../useProductStatuses';
 import { useRenderPrice } from '../../useRenderPrice';
 import useResultStyles from './styles';
@@ -44,8 +43,7 @@ const Result = React.memo(
       outOfStockStatusClassName,
       newArrivalStatusClassName,
       disableDefaultStyles = false,
-      onClick: onClickProp,
-      posNegLocalStorageManager,
+      onClick,
       styles: stylesProp,
       showImage: showImageProp = true,
       showVariantImage = false,
@@ -54,26 +52,12 @@ const Result = React.memo(
       ...rest
     } = props;
     const { t } = useTranslation('result');
-    const { currency, language, ratingMax, tracking } = useSearchUIContext();
-    const { href, onClick: clickTrackingOnClick } = applyClickTracking({
-      token,
-      tracking,
-      values,
-      onClick: onClickProp,
-    });
-    const { onClick: posNegOnClick } = applyPosNegTracking({
-      token,
-      tracking,
-      values,
-      onClick: onClickProp,
-      posNegLocalStorageManager,
-    });
+    const { currency, language, ratingMax } = useSearchUIContext();
     const { title, description, subtitle, image } = values;
     const [imageSrc, setImageSrc] = useState(isArray(image) ? image[0] : image);
     const [hoverImageSrc] = useState(isArray(image) && !showVariantImage ? image[1] : undefined);
     const rating = Number(values.rating);
     const [activeImageIndex, setActiveImageIndex] = useState<number>(0);
-    const onClick = tracking instanceof ClickTracking ? clickTrackingOnClick : posNegOnClick;
     const newTabProps = openNewTab ? { target: '_blank', rel: 'noopener' } : {};
     const { isOnSale, isOutOfStock, isNewArrival, onSaleText, newArrivalText, outOfStockText } = useProductStatuses({
       activeImageIndex,

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -32,7 +32,7 @@ const Result = React.memo(
       imageAspectRatio: imageAspectRatioProp = 1,
       imageObjectFit: imageObjectFitProp = 'contain',
       values,
-      token,
+      href,
       forceImage,
       headingClassName,
       priceClassName,

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-target-blank */
 import { Box, Heading, Image, ImageProps, Link, Rating, Text } from '@sajari/react-components';
-import { ClickTracking } from '@sajari/react-hooks';
+import { ClickTracking, useTracking } from '@sajari/react-hooks';
 import {
   __DEV__,
   decodeHTML,
@@ -17,6 +17,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../../../ContextProvider';
+import { applyClickTracking, applyPosNegTracking } from '../../../utils';
 import { useProductStatuses } from '../../useProductStatuses';
 import { useRenderPrice } from '../../useRenderPrice';
 import useResultStyles from './styles';
@@ -30,8 +31,7 @@ const Result = React.memo(
       appearance = 'list',
       imageAspectRatio: imageAspectRatioProp = 1,
       imageObjectFit: imageObjectFitProp = 'contain',
-      values,
-      href,
+      result: { values, token },
       forceImage,
       headingClassName,
       priceClassName,
@@ -43,7 +43,6 @@ const Result = React.memo(
       outOfStockStatusClassName,
       newArrivalStatusClassName,
       disableDefaultStyles = false,
-      onClick,
       styles: stylesProp,
       showImage: showImageProp = true,
       showVariantImage = false,
@@ -52,12 +51,27 @@ const Result = React.memo(
       ...rest
     } = props;
     const { t } = useTranslation('result');
-    const { currency, language, ratingMax } = useSearchUIContext();
+    const { posNegLocalStorageManager, handleResultClicked: onClickProp } = useTracking();
+    const { currency, language, ratingMax, tracking } = useSearchUIContext();
+    const { href, onClick: clickTrackingOnClick } = applyClickTracking({
+      token,
+      tracking,
+      values,
+      onClick: onClickProp,
+    });
+    const { onClick: posNegOnClick } = applyPosNegTracking({
+      token,
+      tracking,
+      values,
+      onClick: onClickProp,
+      posNegLocalStorageManager,
+    });
     const { title, description, subtitle, image } = values;
     const [imageSrc, setImageSrc] = useState(isArray(image) ? image[0] : image);
     const [hoverImageSrc] = useState(isArray(image) && !showVariantImage ? image[1] : undefined);
     const rating = Number(values.rating);
     const [activeImageIndex, setActiveImageIndex] = useState<number>(0);
+    const onClick = tracking instanceof ClickTracking ? clickTrackingOnClick : posNegOnClick;
     const newTabProps = openNewTab ? { target: '_blank', rel: 'noopener' } : {};
     const { isOnSale, isOutOfStock, isNewArrival, onSaleText, newArrivalText, outOfStockText } = useProductStatuses({
       activeImageIndex,

--- a/packages/search-ui/src/Results/components/Result/types.ts
+++ b/packages/search-ui/src/Results/components/Result/types.ts
@@ -1,5 +1,4 @@
 import { BoxProps } from '@sajari/react-components';
-import { PosNegLocalStorageManager } from '@sajari/sdk-js';
 import * as React from 'react';
 
 import { ApplyClickTrackingParams } from '../../../utils';
@@ -10,10 +9,8 @@ interface Props extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | '
   values: ResultValues;
   /** The url used for tracking/analytics */
   href?: string;
-  /** Used to store pos tokens after click for later consumption */
-  posNegLocalStorageManager: PosNegLocalStorageManager;
   /** Handle clicking a result */
-  onClick?: ApplyClickTrackingParams['onClick'];
+  onClick?: () => void;
   /** Open the result link in a new tab */
   openNewTab?: boolean;
   /** Display image or not */

--- a/packages/search-ui/src/Results/components/Result/types.ts
+++ b/packages/search-ui/src/Results/components/Result/types.ts
@@ -7,7 +7,7 @@ import { ResultsProps, ResultValues } from '../../types';
 interface Props extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | 'imageObjectFit'>, BoxProps {
   /** Search result values */
   values: ResultValues;
-  /** The url used for tracking/analytics */
+  /** The url of the result or the tracking url (if tracking is enabled) */
   href?: string;
   /** Handle clicking a result */
   onClick?: () => void;

--- a/packages/search-ui/src/Results/components/Result/types.ts
+++ b/packages/search-ui/src/Results/components/Result/types.ts
@@ -1,16 +1,12 @@
 import { BoxProps } from '@sajari/react-components';
+import type { Token } from '@sajari/react-hooks';
 import * as React from 'react';
 
-import { ApplyClickTrackingParams } from '../../../utils';
 import { ResultsProps, ResultValues } from '../../types';
 
 interface Props extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | 'imageObjectFit'>, BoxProps {
   /** Search result values */
-  values: ResultValues;
-  /** The url of the result or the tracking url (if tracking is enabled) */
-  href?: string;
-  /** Handle clicking a result */
-  onClick?: () => void;
+  result: { values: ResultValues; token?: Token };
   /** Open the result link in a new tab */
   openNewTab?: boolean;
   /** Display image or not */

--- a/packages/search-ui/src/Results/components/Result/types.ts
+++ b/packages/search-ui/src/Results/components/Result/types.ts
@@ -1,5 +1,4 @@
 import { BoxProps } from '@sajari/react-components';
-import { Token } from '@sajari/react-hooks';
 import { PosNegLocalStorageManager } from '@sajari/sdk-js';
 import * as React from 'react';
 
@@ -9,8 +8,8 @@ import { ResultsProps, ResultValues } from '../../types';
 interface Props extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | 'imageObjectFit'>, BoxProps {
   /** Search result values */
   values: ResultValues;
-  /** The token used for tracking/analytics */
-  token?: Token;
+  /** The url used for tracking/analytics */
+  href?: string;
   /** Used to store pos tokens after click for later consumption */
   posNegLocalStorageManager: PosNegLocalStorageManager;
   /** Handle clicking a result */

--- a/packages/search-ui/src/Results/components/TemplateResult/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResult/index.tsx
@@ -1,25 +1,40 @@
 import { Box } from '@sajari/react-components';
+import { mergeRefs } from '@sajari/react-sdk-utils';
 import { useSearchUIContext } from '@sajari/react-search-ui';
 import React from 'react';
 
 import { useHoverImage } from '../../useHoverImage';
+import { useProductImages } from '../../useProductImages';
 import { useProductStatuses } from '../../useProductStatuses';
 import { useRenderPrice } from '../../useRenderPrice';
 import { TemplateResultProps } from './types';
 
 const TemplateResult = (props: TemplateResultProps) => {
-  const { customClassNames, currency, language } = useSearchUIContext();
+  const { customClassNames, currency, language, viewType } = useSearchUIContext();
   const { render, values, as, showVariantImage } = props;
+  const { onRefChange: onRefChangeProductImages, activeImageIndex } = useProductImages({
+    viewType,
+    values,
+    showVariantImage,
+  });
   const productStatuses = useProductStatuses({
+    activeImageIndex,
     values,
   });
-  const renderPriceData = useRenderPrice({ values, currency, language, isOnSale: productStatuses.isOnSale });
+  const renderPriceData = useRenderPrice({
+    values,
+    currency,
+    language,
+    isOnSale: productStatuses.isOnSale,
+    activeImageIndex,
+  });
   const rendered = render({ ...values, productStatuses, renderPriceData });
-  const onRefChange = useHoverImage({ image: values.image, showVariantImage });
+  const onRefChangeHoverImage = useHoverImage({ image: values.image, showVariantImage });
+  const ref = mergeRefs(onRefChangeHoverImage, onRefChangeProductImages);
 
   return (
     <Box
-      ref={onRefChange}
+      ref={ref}
       as={as}
       className={customClassNames.results?.template?.resultContainer}
       dangerouslySetInnerHTML={{ __html: rendered }}

--- a/packages/search-ui/src/Results/components/TemplateResult/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResult/index.tsx
@@ -2,12 +2,18 @@ import { Box } from '@sajari/react-components';
 import { useSearchUIContext } from '@sajari/react-search-ui';
 import React from 'react';
 
+import { useProductStatuses } from '../../useProductStatuses';
+import { useRenderPrice } from '../../useRenderPrice';
 import { TemplateResultProps } from './types';
 
 const TemplateResult = (props: TemplateResultProps) => {
-  const { customClassNames } = useSearchUIContext();
+  const { customClassNames, currency, language } = useSearchUIContext();
   const { render, values, as } = props;
-  const rendered = render(values);
+  const productStatuses = useProductStatuses({
+    values,
+  });
+  const renderPriceData = useRenderPrice({ values, currency, language, isOnSale: productStatuses.isOnSale });
+  const rendered = render({ ...values, productStatuses, renderPriceData });
 
   return (
     <Box

--- a/packages/search-ui/src/Results/components/TemplateResult/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResult/index.tsx
@@ -2,21 +2,24 @@ import { Box } from '@sajari/react-components';
 import { useSearchUIContext } from '@sajari/react-search-ui';
 import React from 'react';
 
+import { useHoverImage } from '../../useHoverImage';
 import { useProductStatuses } from '../../useProductStatuses';
 import { useRenderPrice } from '../../useRenderPrice';
 import { TemplateResultProps } from './types';
 
 const TemplateResult = (props: TemplateResultProps) => {
   const { customClassNames, currency, language } = useSearchUIContext();
-  const { render, values, as } = props;
+  const { render, values, as, showVariantImage } = props;
   const productStatuses = useProductStatuses({
     values,
   });
   const renderPriceData = useRenderPrice({ values, currency, language, isOnSale: productStatuses.isOnSale });
   const rendered = render({ ...values, productStatuses, renderPriceData });
+  const onRefChange = useHoverImage({ image: values.image, showVariantImage });
 
   return (
     <Box
+      ref={onRefChange}
       as={as}
       className={customClassNames.results?.template?.resultContainer}
       dangerouslySetInnerHTML={{ __html: rendered }}

--- a/packages/search-ui/src/Results/components/TemplateResult/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResult/index.tsx
@@ -11,7 +11,7 @@ import { TemplateResultProps } from './types';
 
 const TemplateResult = (props: TemplateResultProps) => {
   const { customClassNames, currency, language, viewType } = useSearchUIContext();
-  const { render, values, as, showVariantImage } = props;
+  const { render, values, as, showVariantImage, onClick } = props;
   const { onRefChange: onRefChangeProductImages, activeImageIndex } = useProductImages({
     viewType,
     values,
@@ -34,6 +34,7 @@ const TemplateResult = (props: TemplateResultProps) => {
 
   return (
     <Box
+      onClick={onClick}
       ref={ref}
       as={as}
       className={customClassNames.results?.template?.resultContainer}

--- a/packages/search-ui/src/Results/components/TemplateResult/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResult/types.ts
@@ -12,6 +12,7 @@ type ExtraValues = {
 
 interface Props extends Pick<TemplateResultsProps, 'showVariantImage'> {
   values: ResultValues;
+  onClick?: () => void;
   render: (v: ResultValues & ExtraValues) => string;
 }
 

--- a/packages/search-ui/src/Results/components/TemplateResult/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResult/types.ts
@@ -1,3 +1,4 @@
+import type { Token } from '@sajari/react-hooks';
 import { PropsWithAs } from '@sajari/react-sdk-utils';
 
 import { ResultValues } from '../../types';
@@ -11,8 +12,7 @@ type ExtraValues = {
 };
 
 interface Props extends Pick<TemplateResultsProps, 'showVariantImage'> {
-  values: ResultValues;
-  onClick?: () => void;
+  result: { values: ResultValues; token?: Token };
   render: (v: ResultValues & ExtraValues) => string;
 }
 

--- a/packages/search-ui/src/Results/components/TemplateResult/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResult/types.ts
@@ -3,13 +3,14 @@ import { PropsWithAs } from '@sajari/react-sdk-utils';
 import { ResultValues } from '../../types';
 import { UseProductStatusesOutput } from '../../useProductStatuses';
 import { UseRenderPriceOutput } from '../../useRenderPrice';
+import { TemplateResultsProps } from '../TemplateResults/types';
 
 type ExtraValues = {
   productStatuses: UseProductStatusesOutput;
   renderPriceData: UseRenderPriceOutput;
 };
 
-interface Props {
+interface Props extends Pick<TemplateResultsProps, 'showVariantImage'> {
   values: ResultValues;
   render: (v: ResultValues & ExtraValues) => string;
 }

--- a/packages/search-ui/src/Results/components/TemplateResult/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResult/types.ts
@@ -1,10 +1,17 @@
 import { PropsWithAs } from '@sajari/react-sdk-utils';
 
 import { ResultValues } from '../../types';
+import { UseProductStatusesOutput } from '../../useProductStatuses';
+import { UseRenderPriceOutput } from '../../useRenderPrice';
+
+type ExtraValues = {
+  productStatuses: UseProductStatusesOutput;
+  renderPriceData: UseRenderPriceOutput;
+};
 
 interface Props {
   values: ResultValues;
-  render: (v: ResultValues) => string;
+  render: (v: ResultValues & ExtraValues) => string;
 }
 
 export type TemplateResultProps = PropsWithAs<Props, 'div'>;

--- a/packages/search-ui/src/Results/components/TemplateResults/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResults/index.tsx
@@ -37,12 +37,11 @@ const TemplateResults = (props: TemplateResultsProps) => {
           `}
         />
       ) : null}
-      {results?.map(({ values, onClick }, i) => (
+      {results?.map((result, i) => (
         <TemplateResult
-          onClick={onClick}
           // eslint-disable-next-line no-underscore-dangle
-          key={values._id ?? i}
-          values={values}
+          key={result.values._id ?? i}
+          result={result}
           render={render}
           as={resultContainerTemplateElement}
           {...rest}

--- a/packages/search-ui/src/Results/components/TemplateResults/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResults/index.tsx
@@ -12,10 +12,12 @@ const TemplateResults = (props: TemplateResultsProps) => {
   const { results, resultTemplate, resultContainerTemplateElement, ...rest } = props;
   // Get the keys of a result, using Set to eliminate dups
   const keys = Array.from(
-    results?.reduce((acc, cur) => {
-      Object.keys(cur).forEach((k) => acc.add(k));
-      return acc;
-    }, new Set<string>()),
+    results
+      .map((r) => r.values)
+      .reduce((acc, cur) => {
+        Object.keys(cur).forEach((k) => acc.add(k));
+        return acc;
+      }, new Set<string>()),
   );
   keys.push('productStatuses');
   keys.push('renderPriceData');
@@ -35,8 +37,9 @@ const TemplateResults = (props: TemplateResultsProps) => {
           `}
         />
       ) : null}
-      {results?.map((values, i) => (
+      {results?.map(({ values, onClick }, i) => (
         <TemplateResult
+          onClick={onClick}
           // eslint-disable-next-line no-underscore-dangle
           key={values._id ?? i}
           values={values}

--- a/packages/search-ui/src/Results/components/TemplateResults/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResults/index.tsx
@@ -17,6 +17,8 @@ const TemplateResults = (props: TemplateResultsProps) => {
       return acc;
     }, new Set<string>()),
   );
+  keys.push('productStatuses');
+  keys.push('renderPriceData');
   const keysStringified = keys.join(',');
   const render = useMemo(() => compile(resultTemplate.html, { async: false, props: keys }), [
     resultTemplate.html,

--- a/packages/search-ui/src/Results/components/TemplateResults/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResults/index.tsx
@@ -9,7 +9,7 @@ import { TemplateResultsProps } from './types';
 
 const TemplateResults = (props: TemplateResultsProps) => {
   const { customClassNames } = useSearchUIContext();
-  const { results, resultTemplate, resultContainerTemplateElement } = props;
+  const { results, resultTemplate, resultContainerTemplateElement, ...rest } = props;
   // Get the keys of a result, using Set to eliminate dups
   const keys = Array.from(
     results?.reduce((acc, cur) => {
@@ -42,6 +42,7 @@ const TemplateResults = (props: TemplateResultsProps) => {
           values={values}
           render={render}
           as={resultContainerTemplateElement}
+          {...rest}
         />
       ))}
     </div>

--- a/packages/search-ui/src/Results/components/TemplateResults/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResults/types.ts
@@ -1,10 +1,10 @@
-import { ResultValues } from '@sajari/react-hooks';
+import type { ResultValues, Token } from '@sajari/react-hooks';
 
 import type { ResultsProps, ResultTemplate } from '../../types';
 
 interface Props extends Pick<ResultsProps, 'resultContainerTemplateElement' | 'showVariantImage'> {
   resultTemplate: ResultTemplate;
-  results: { values: ResultValues; onClick?: () => void }[];
+  results: { values: ResultValues; token?: Token }[];
 }
 
 export type TemplateResultsProps = Props;

--- a/packages/search-ui/src/Results/components/TemplateResults/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResults/types.ts
@@ -1,8 +1,8 @@
 import { ResultValues } from '@sajari/react-hooks';
 
-import { ResultsProps, ResultTemplate } from '../../types';
+import type { ResultsProps, ResultTemplate } from '../../types';
 
-interface Props extends Pick<ResultsProps, 'resultContainerTemplateElement'> {
+interface Props extends Pick<ResultsProps, 'resultContainerTemplateElement' | 'showVariantImage'> {
   resultTemplate: ResultTemplate;
   results: ResultValues[];
 }

--- a/packages/search-ui/src/Results/components/TemplateResults/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResults/types.ts
@@ -4,7 +4,7 @@ import type { ResultsProps, ResultTemplate } from '../../types';
 
 interface Props extends Pick<ResultsProps, 'resultContainerTemplateElement' | 'showVariantImage'> {
   resultTemplate: ResultTemplate;
-  results: ResultValues[];
+  results: { values: ResultValues; onClick?: () => void }[];
 }
 
 export type TemplateResultsProps = Props;

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -108,6 +108,7 @@ const Results = (props: ResultsProps) => {
         resetKeys={[`${resultTemplate.html}${resultTemplate.css}`]}
       >
         <TemplateResults
+          showVariantImage={rest.showVariantImage}
           results={results.map((r) => r.values)}
           resultTemplate={resultTemplate}
           resultContainerTemplateElement={resultContainerTemplateElement}

--- a/packages/search-ui/src/Results/useHoverImage.ts
+++ b/packages/search-ui/src/Results/useHoverImage.ts
@@ -8,13 +8,15 @@ interface Props extends Pick<TemplateResultProps, 'showVariantImage'> {
   image: ResultValues['image'];
 }
 
-export function useHoverImage(props: Props) {
+type UseHoverImageOutput = (element: HTMLElement | null) => void;
+
+export function useHoverImage(props: Props): UseHoverImageOutput {
   const { image: imageProp, showVariantImage } = props;
   const hoverImageSrc = isArray(imageProp) ? imageProp[1] : undefined;
   const [image, setImage] = useState<HTMLImageElement | null>(null);
   const [secondImage, setSecondImage] = useState<HTMLImageElement | null>(null);
 
-  const onRefChange = useCallback((element: HTMLElement | null) => {
+  const onRefChange = useCallback<UseHoverImageOutput>((element) => {
     const node = element;
     if (node) {
       const img = node.querySelector('img[data-sj-first-image]') as HTMLImageElement;

--- a/packages/search-ui/src/Results/useHoverImage.ts
+++ b/packages/search-ui/src/Results/useHoverImage.ts
@@ -1,0 +1,80 @@
+import { isArray } from '@sajari/react-sdk-utils';
+import { useCallback, useEffect, useState } from 'react';
+
+import { TemplateResultProps } from './components/TemplateResult/types';
+import { ResultValues } from './types';
+
+interface Props extends Pick<TemplateResultProps, 'showVariantImage'> {
+  image: ResultValues['image'];
+}
+
+export function useHoverImage(props: Props) {
+  const { image: imageProp, showVariantImage } = props;
+  const hoverImageSrc = isArray(imageProp) ? imageProp[1] : undefined;
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+  const [secondImage, setSecondImage] = useState<HTMLImageElement | null>(null);
+
+  const onRefChange = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      const img = node.querySelector('img[data-sj-first-image]') as HTMLImageElement;
+      setImage(img);
+    }
+  }, []);
+
+  const onMouseEnter = useCallback(() => {
+    if (image && secondImage) {
+      image.style.opacity = '0';
+      secondImage.style.opacity = '100';
+    }
+  }, [image, secondImage]);
+
+  const onMouseLeave = useCallback(() => {
+    if (image && secondImage) {
+      image.style.opacity = '100';
+      secondImage.style.opacity = '0';
+    }
+  }, [image, secondImage]);
+
+  useEffect(() => {
+    if (hoverImageSrc && image && !showVariantImage) {
+      const secondImageElement = document.createElement('img');
+      secondImageElement.src = hoverImageSrc;
+      secondImageElement.dataset.sjSecondImage = '';
+      secondImageElement.style.transition = 'opacity 0.2s ease-in';
+      secondImageElement.style.opacity = '0';
+      secondImageElement.style.position = 'absolute';
+      secondImageElement.style.top = '0';
+      secondImageElement.style.left = '0';
+      secondImageElement.style.height = '100%';
+      secondImageElement.style.width = '100%';
+      secondImageElement.style.objectFit = 'contain';
+      secondImageElement.style.objectPosition = 'center';
+      setSecondImage(secondImageElement);
+      image.insertAdjacentElement('beforebegin', secondImageElement);
+    }
+  }, [hoverImageSrc, image, showVariantImage]);
+
+  useEffect(() => {
+    if (showVariantImage && secondImage && image) {
+      secondImage.remove();
+      image.style.removeProperty('transtion');
+      image.style.removeProperty('opacity');
+    }
+  }, [showVariantImage]);
+
+  useEffect(() => {
+    if (image) {
+      image.style.transition = 'opacity 0.2s ease-in';
+      image.style.opacity = '100';
+      image.addEventListener('mouseenter', onMouseEnter);
+      image.addEventListener('mouseleave', onMouseLeave);
+    }
+
+    return () => {
+      image?.removeEventListener('mouseenter', onMouseEnter);
+      image?.removeEventListener('mouseleave', onMouseLeave);
+    };
+  }, [image, onMouseEnter, onMouseLeave]);
+
+  return onRefChange;
+}

--- a/packages/search-ui/src/Results/useHoverImage.ts
+++ b/packages/search-ui/src/Results/useHoverImage.ts
@@ -14,7 +14,8 @@ export function useHoverImage(props: Props) {
   const [image, setImage] = useState<HTMLImageElement | null>(null);
   const [secondImage, setSecondImage] = useState<HTMLImageElement | null>(null);
 
-  const onRefChange = useCallback((node: HTMLElement | null) => {
+  const onRefChange = useCallback((element: HTMLElement | null) => {
+    const node = element;
     if (node) {
       const img = node.querySelector('img[data-sj-first-image]') as HTMLImageElement;
       setImage(img);
@@ -22,16 +23,20 @@ export function useHoverImage(props: Props) {
   }, []);
 
   const onMouseEnter = useCallback(() => {
-    if (image && secondImage) {
-      image.style.opacity = '0';
-      secondImage.style.opacity = '100';
+    if (image && secondImage && showVariantImage) {
+      image.style.opacity = '0%';
+      secondImage.style.opacity = '100%';
+    } else if (image) {
+      image.style.opacity = '70%';
     }
   }, [image, secondImage]);
 
   const onMouseLeave = useCallback(() => {
-    if (image && secondImage) {
-      image.style.opacity = '100';
-      secondImage.style.opacity = '0';
+    if (image && secondImage && showVariantImage) {
+      image.style.opacity = '100%';
+      secondImage.style.opacity = '0%';
+    } else if (image) {
+      image.style.opacity = '100%';
     }
   }, [image, secondImage]);
 
@@ -41,7 +46,7 @@ export function useHoverImage(props: Props) {
       secondImageElement.src = hoverImageSrc;
       secondImageElement.dataset.sjSecondImage = '';
       secondImageElement.style.transition = 'opacity 0.2s ease-in';
-      secondImageElement.style.opacity = '0';
+      secondImageElement.style.opacity = '0%';
       secondImageElement.style.position = 'absolute';
       secondImageElement.style.top = '0';
       secondImageElement.style.left = '0';
@@ -64,8 +69,10 @@ export function useHoverImage(props: Props) {
 
   useEffect(() => {
     if (image) {
-      image.style.transition = 'opacity 0.2s ease-in';
-      image.style.opacity = '100';
+      if (!showVariantImage) {
+        image.style.transition = 'opacity 0.2s ease-in';
+        image.style.opacity = '100%';
+      }
       image.addEventListener('mouseenter', onMouseEnter);
       image.addEventListener('mouseleave', onMouseLeave);
     }

--- a/packages/search-ui/src/Results/useHoverImage.ts
+++ b/packages/search-ui/src/Results/useHoverImage.ts
@@ -23,22 +23,22 @@ export function useHoverImage(props: Props) {
   }, []);
 
   const onMouseEnter = useCallback(() => {
-    if (image && secondImage && showVariantImage) {
+    if (image && secondImage && !showVariantImage) {
       image.style.opacity = '0%';
       secondImage.style.opacity = '100%';
     } else if (image) {
       image.style.opacity = '70%';
     }
-  }, [image, secondImage]);
+  }, [image, secondImage, showVariantImage]);
 
   const onMouseLeave = useCallback(() => {
-    if (image && secondImage && showVariantImage) {
+    if (image && secondImage && !showVariantImage) {
       image.style.opacity = '100%';
       secondImage.style.opacity = '0%';
     } else if (image) {
       image.style.opacity = '100%';
     }
-  }, [image, secondImage]);
+  }, [image, secondImage, showVariantImage]);
 
   useEffect(() => {
     if (hoverImageSrc && image && !showVariantImage) {

--- a/packages/search-ui/src/Results/useProductImages.ts
+++ b/packages/search-ui/src/Results/useProductImages.ts
@@ -1,0 +1,168 @@
+import { isArray } from '@sajari/react-sdk-utils';
+import { useCallback, useEffect, useState } from 'react';
+
+import { ResultViewType } from '../ContextProvider';
+import { TemplateResultProps } from './components/TemplateResult/types';
+import { ResultValues } from './types';
+
+interface Props extends Pick<TemplateResultProps, 'showVariantImage'> {
+  viewType: ResultViewType;
+  values: ResultValues;
+}
+
+const baseStyle = {
+  display: 'flex',
+  'flex-wrap': 'wrap',
+  gap: '0.25rem',
+  width: '100%',
+  'margin-top': '0.5rem',
+};
+
+const gridStyle = {
+  ...baseStyle,
+  'margin-right': 'auto',
+  'margin-left': 'auto',
+  'justify-content': 'center',
+  'max-width': 'fit-content',
+};
+
+const listStyle = {
+  ...baseStyle,
+  'margin-right': 'unset',
+  'margin-left': 'unset',
+  'justify-content': 'unset',
+  'max-width': 'unset',
+};
+
+const imgStyle = {
+  outerContainer: {
+    width: '2.25rem',
+    height: '2.25rem',
+    outline: 'transparent solid 2px',
+    'outline-offset': '2px',
+    'border-radius': '0.375rem',
+    padding: '0.125rem',
+    'border-color': 'transparent',
+  },
+  innerContainer: {
+    position: 'relative',
+    'border-radius': '0.125rem',
+  },
+  pseudoElement: {
+    'padding-bottom': 'calc(100%)',
+    display: 'block',
+    height: '0px',
+  },
+  img: {
+    'object-fit': 'cover',
+    'object-position': 'center top',
+    'border-radius': 'inherit',
+    position: 'absolute',
+    top: '0px',
+    left: '0px',
+    width: '100%',
+    height: '100%',
+  },
+};
+
+function getCreateImageElementFunc(setIndex: (i: number) => void) {
+  return function createImageElement(src: string, i: number) {
+    const imgContainer = document.createElement('div');
+    imgContainer.setAttribute('role', 'img');
+    imgContainer.tabIndex = 0;
+    Object.entries(imgStyle.outerContainer).forEach(([key, value]) => {
+      imgContainer.style.setProperty(key, value);
+    });
+
+    const innerContainer = document.createElement('div');
+    innerContainer.dataset.sjVariantImage = '';
+    Object.entries(imgStyle.innerContainer).forEach(([key, value]) => {
+      innerContainer.style.setProperty(key, value);
+    });
+
+    const img = document.createElement('img');
+    img.src = src;
+    img.loading = 'lazy';
+    img.addEventListener('mouseenter', () => {
+      setIndex(i);
+    });
+    Object.entries(imgStyle.img).forEach(([key, value]) => {
+      img.style.setProperty(key, value);
+    });
+
+    innerContainer.appendChild(img);
+    imgContainer.appendChild(innerContainer);
+
+    return imgContainer;
+  };
+}
+
+export function useProductImages(props: Props) {
+  const { viewType, values, showVariantImage } = props;
+  const [activeImageIndex, setActiveImageIndex] = useState(0);
+  const [node, setNode] = useState<HTMLElement | null>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  const onRefChange = useCallback((element: HTMLElement | null) => {
+    if (element) {
+      setNode(element);
+      const containerElement = element.querySelector('div[data-sj-product-images-container]') as HTMLElement;
+      setContainer(containerElement);
+    }
+  }, []);
+
+  useEffect(() => {
+    switch (viewType) {
+      case 'grid':
+        if (container && showVariantImage) {
+          Object.entries(gridStyle).forEach(([key, value]) => {
+            container.style.setProperty(key, value);
+          });
+        }
+        break;
+      case 'list':
+      default:
+        if (container && showVariantImage) {
+          Object.entries(listStyle).forEach(([key, value]) => {
+            container.style.setProperty(key, value);
+          });
+        }
+        break;
+    }
+  }, [viewType, container, showVariantImage]);
+
+  useEffect(() => {
+    if (node) {
+      const img = node.querySelector('img[data-sj-first-image]') as HTMLImageElement;
+      const { image } = values;
+      if (img && isArray(image) && image[activeImageIndex]) {
+        img.src = image[activeImageIndex];
+      }
+    }
+  }, [activeImageIndex]);
+
+  useEffect(() => {
+    const { image } = values;
+    if (container && showVariantImage && isArray(image)) {
+      const style = document.createElement('style');
+      style.id = 'sj-result-template-default-style';
+      style.textContent = `
+        [data-sj-variant-image]::before {
+          padding-bottom: calc(100%);
+          content: "";
+          display: block;
+          height: 0px;
+        }
+      `;
+      document.head.appendChild(style);
+      const images = image.map(getCreateImageElementFunc(setActiveImageIndex));
+      images.forEach((img) => {
+        container.appendChild(img);
+      });
+    } else {
+      document.querySelector('#sj-result-template-default-style')?.remove();
+    }
+  }, [container, showVariantImage]);
+
+  return { onRefChange, activeImageIndex };
+}

--- a/packages/search-ui/src/Results/useProductImages.ts
+++ b/packages/search-ui/src/Results/useProductImages.ts
@@ -97,13 +97,18 @@ function getCreateImageElementFunc(setIndex: (i: number) => void) {
   };
 }
 
-export function useProductImages(props: Props) {
+type UseProductImagesOutput = {
+  onRefChange: (element: HTMLElement | null) => void;
+  activeImageIndex: number;
+};
+
+export function useProductImages(props: Props): UseProductImagesOutput {
   const { viewType, values, showVariantImage } = props;
   const [activeImageIndex, setActiveImageIndex] = useState(0);
   const [node, setNode] = useState<HTMLElement | null>(null);
   const [container, setContainer] = useState<HTMLElement | null>(null);
 
-  const onRefChange = useCallback((element: HTMLElement | null) => {
+  const onRefChange = useCallback<UseProductImagesOutput['onRefChange']>((element) => {
     if (element) {
       setNode(element);
       const containerElement = element.querySelector('div[data-sj-product-images-container]') as HTMLElement;

--- a/packages/search-ui/src/Results/useProductStatuses.ts
+++ b/packages/search-ui/src/Results/useProductStatuses.ts
@@ -1,0 +1,94 @@
+import { isArray, isEmpty, isNumber } from '@sajari/react-sdk-utils';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ResultValues } from './types';
+
+dayjs.extend(utc);
+
+type Input = {
+  activeImageIndex?: number;
+  values: ResultValues;
+};
+
+export type UseProductStatusesOutput = {
+  isOnSale: boolean;
+  isOutOfStock: boolean;
+  isNewArrival: boolean;
+  onSaleText: string;
+  newArrivalText: string;
+  outOfStockText: string;
+};
+
+export function useProductStatuses({ activeImageIndex = 0, values }: Input): UseProductStatusesOutput {
+  const { quantity, price, originalPrice, salePrice, createdAt } = values;
+  const { t } = useTranslation('result');
+
+  const isNewArrival = useMemo(() => {
+    if (!createdAt) {
+      return false;
+    }
+
+    const parsedCreatedAt = dayjs(createdAt);
+    const current = dayjs();
+
+    return current.diff(parsedCreatedAt, 'day') <= 30 && activeImageIndex === 0;
+  }, [createdAt, activeImageIndex]);
+
+  const isOnSale = useMemo(() => {
+    if (!price || (!originalPrice && !salePrice)) {
+      return false;
+    }
+
+    const parsePrices = (input: string | Array<string>) => (isArray(input) ? input : [input]).map(Number);
+    const prices = parsePrices(price);
+    const originalPrices = !originalPrice ? false : parsePrices(originalPrice);
+    const salePrices = !salePrice ? false : parsePrices(salePrice);
+
+    if (originalPrices) {
+      if (originalPrices.length >= prices.length) {
+        return prices.some((p, index) => isNumber(p) && isNumber(originalPrices[index]) && p < originalPrices[index]);
+      }
+      if (originalPrices && originalPrices.length === 1 && prices.length > 1) {
+        const [original] = originalPrices;
+        return isNumber(original) && prices.some((p) => isNumber(p) && p < original);
+      }
+    }
+
+    if (salePrices) {
+      if (!salePrices.some((p) => p !== 0)) {
+        return false;
+      }
+      if (salePrices.length >= prices.length) {
+        return prices.some((p, index) => isNumber(p) && isNumber(salePrices[index]) && p > salePrices[index]);
+      }
+      if (salePrices && salePrices.length === 1 && prices.length > 1) {
+        const [sale] = salePrices;
+        return isNumber(sale) && prices.some((p) => isNumber(p) && p > sale);
+      }
+    }
+
+    return false;
+  }, []);
+
+  const isOutOfStock = useMemo(() => {
+    if (isEmpty(quantity)) {
+      return false;
+    }
+    const parseQuantities = (input: string | Array<string>) => (isArray(input) ? input : [input]).map(Number);
+    const quantities = parseQuantities(quantity);
+
+    return quantities[activeImageIndex] === 0;
+  }, [activeImageIndex]);
+
+  return {
+    isNewArrival,
+    isOutOfStock,
+    isOnSale,
+    outOfStockText: t('status.outOfStock'),
+    onSaleText: t('status.onSale'),
+    newArrivalText: t('status.newArrival'),
+  };
+}

--- a/packages/search-ui/src/Results/useRenderPrice.ts
+++ b/packages/search-ui/src/Results/useRenderPrice.ts
@@ -1,0 +1,59 @@
+import { formatPrice, isArray, isEmpty } from '@sajari/react-sdk-utils';
+
+import type { ResultValues } from './types';
+
+type Input = {
+  activeImageIndex?: number;
+  values: ResultValues;
+  isOnSale: boolean;
+  currency: string;
+  language?: string;
+};
+
+export type UseRenderPriceOutput = {
+  priceToDisplay: string;
+  markedDownFromPriceToDisplay?: string;
+} | null;
+
+export function useRenderPrice({
+  values,
+  activeImageIndex = 0,
+  isOnSale,
+  currency,
+  language,
+}: Input): UseRenderPriceOutput {
+  const { price, salePrice, originalPrice } = values;
+  if (isEmpty(price)) return null;
+  const activePrice = isArray(price) ? price[activeImageIndex] ?? price : price;
+  if (isEmpty(activePrice)) return null;
+  let priceToDisplay: string;
+  let markedDownFromPriceToDisplay: string | undefined;
+
+  if (originalPrice && isOnSale) {
+    // show `originalPrice` with strikethrough
+    const activeOriginalPrice = isArray(originalPrice)
+      ? originalPrice[activeImageIndex] ?? originalPrice
+      : originalPrice ?? '';
+    priceToDisplay = formatPrice(activePrice, { currency, language });
+    markedDownFromPriceToDisplay = formatPrice(activeOriginalPrice, { currency, language });
+  } else if (salePrice && isOnSale) {
+    // show `price` with strikethrough
+    const activeSalePrice = isArray(salePrice) ? salePrice[activeImageIndex] ?? salePrice : salePrice ?? '';
+    if (activeSalePrice !== '0') {
+      priceToDisplay = formatPrice(activeSalePrice, { currency, language });
+      markedDownFromPriceToDisplay = formatPrice(activePrice, { currency, language });
+    } else {
+      // Sajari engine coerces nullish doubles to 0. We need to check for '0' salePrice and
+      // print the ordinary price instead to avoid showing the product on sale for free.
+      priceToDisplay = formatPrice(activePrice, { currency, language });
+    }
+  } else {
+    // Standard price, show `price` and with no sale styling.
+    priceToDisplay = formatPrice(activePrice, { currency, language });
+  }
+
+  return {
+    priceToDisplay,
+    markedDownFromPriceToDisplay,
+  };
+}

--- a/packages/utils/src/react-helpers.ts
+++ b/packages/utils/src/react-helpers.ts
@@ -36,8 +36,8 @@ export function cleanChildren(children: React.ReactChildren | React.ReactNode): 
   return Children.toArray(children).filter((child) => isValidElement(child)) as React.ReactElement[];
 }
 
-export function assignRef(ref: React.Ref<HTMLElement>, value: HTMLElement): ReturnType<typeof setRef> {
-  if (ref == null) {
+export function assignRef(ref: React.Ref<HTMLElement>, value: HTMLElement | null): ReturnType<typeof setRef> {
+  if (ref == null || value == null) {
     return;
   }
 
@@ -56,7 +56,7 @@ export function assignRef(ref: React.Ref<HTMLElement>, value: HTMLElement): Retu
  * @param refs refs to assign to value to
  */
 export function mergeRefs(...refs: Array<ReactRef<HTMLElement> | undefined>) {
-  return (value: HTMLElement) => {
+  return (value: HTMLElement | null) => {
     refs.forEach((ref) => ref && assignRef(ref, value));
   };
 }


### PR DESCRIPTION
When changing to use result template, we need to keep the following existing features that is offered out-of-the-box when using the `Result` component:
- [x] Ability to render statuses (new arrival, on sale, out of stock) -> extracted to `useProductStatuses` common hook
- [x] Ability to render price (sale price, original price) -> extracted to `useRenderPrice` common hook
- [x] Internationalization -> pass the localized text to the result template for further use
- [x] Ability to change image on hover -> The plan is to use DOM manipulation to add hover logic to an `img` element (perhaps use something like `data-sj-second-image` attribute to hold the second image url)
- [x] Ability to show product variant images -> DOM manipulation
- [x] ClickTracking
- [x] PosNegTracking
