### PR TITLE
fix: range input handles overlap

### DIFF
--- a/.changeset/fuzzy-dots-press.md
+++ b/.changeset/fuzzy-dots-press.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix range input handles overlap if min is to max.

--- a/packages/components/src/RangeInput/index.tsx
+++ b/packages/components/src/RangeInput/index.tsx
@@ -244,10 +244,12 @@ function RangeInput<T extends RangeValue>(props: RangeInputProps<T>) {
     <Box css={[styles.container, stylesProp]} {...rest}>
       <Box css={styles.wrapper}>
         <Box css={styles.ticks}>
-          {ticks.map(({ value: tickValue, getTickProps }) => {
+          {ticks.map(({ value: tickValue, getTickProps }, index) => {
             // Remove width from the styles to prevent needing !important in our styles
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-            const { style, ...tickProps } = getTickProps();
+            const { style, ...tickProps } = getTickProps({
+              styles: min === max ? { left: index === 0 ? '0%' : '100%' } : {},
+            });
             const { width, ...tickStyles } = style as React.CSSProperties;
 
             return (
@@ -276,19 +278,22 @@ function RangeInput<T extends RangeValue>(props: RangeInputProps<T>) {
               {...getSegmentProps({
                 index: i,
                 onClick: (e: React.MouseEvent<HTMLDivElement>) => handleSegmentClick(e, i),
+                styles: i === 1 && min === max ? { width: '100%' } : {},
               })}
             />
           ))}
 
-          {handles.map(({ value: handleValue, active, getHandleProps }) => (
-            <Handle
-              data-value={formatLabel(handleValue)}
-              activeClassName={handleActiveClassName}
-              className={handleClassName}
-              disableDefaultStyles={disableDefaultStyles}
-              {...getHandleProps({ active })}
-            />
-          ))}
+          {handles.map(({ value: handleValue, active, getHandleProps }, index) => {
+            return (
+              <Handle
+                data-value={formatLabel(handleValue)}
+                activeClassName={handleActiveClassName}
+                className={handleClassName}
+                disableDefaultStyles={disableDefaultStyles}
+                {...getHandleProps({ active, styles: min === max ? { left: index === 0 ? '0%' : '100%' } : {} })}
+              />
+            );
+          })}
         </Track>
       </Box>
 


### PR DESCRIPTION
Fix range input handles overlap if `min` is to `max`.

**Before**
![image](https://user-images.githubusercontent.com/12707960/131253786-13e6ac4b-d8f5-4a2c-aa24-35cf9efca8cc.png)

**After**
![image](https://user-images.githubusercontent.com/12707960/131253766-a9998ace-f827-4f15-b00f-4c10b11bb401.png)
