### PR TITLE
fix: missing emotion cache key

### DIFF
--- a/.changeset/hungry-keys-whisper.md
+++ b/.changeset/hungry-keys-whisper.md
@@ -1,0 +1,9 @@
+---
+'@sajari/react-sdk-utils': patch
+'sajari-sdk-docs': patch
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+'@sajari/server': patch
+---
+
+Fix missing setting key for emotion cache which causes a warning if an app requires using multiple emotion caches.

--- a/packages/utils/src/styles/cache.ts
+++ b/packages/utils/src/styles/cache.ts
@@ -5,6 +5,7 @@ import { replaceAll } from '../string';
 const disablePrefix = ['letter-spacing'];
 
 const cache = createCache({
+  key: 'sajari',
   stylisPlugins: (context, content, selectors) => {
     const [selector] = selectors;
 


### PR DESCRIPTION
Fix missing setting key for emotion cache which causes a warning if an app requires using multiple emotion caches - https://emotion.sh/docs/@emotion/cache#key. 

Resolve #605