### PR TITLE
fix: rename misleading hooks

### DIFF
--- a/.changeset/proud-bulldogs-try.md
+++ b/.changeset/proud-bulldogs-try.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': major
+---
+
+Rename misleading hooks - useClickTracking and usePosNegTracking to applyClickTracking and applyPosNegTracking

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -7,8 +7,8 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../ContextProvider';
-import { useClickTracking } from '../hooks';
 import { ResultValues } from '../Results/types';
+import { applyClickTracking } from '../utils';
 import mapResultFields from '../utils/mapResultFields';
 import { InputProps } from './types';
 
@@ -69,7 +69,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.Ref<HTMLInput
         results.splice(0, maxSuggestions).map((result) => {
           const { values, token } = result;
           const { description, image, title } = values;
-          const { href, onClick } = useClickTracking({ tracking, values, token });
+          const { href, onClick } = applyClickTracking({ tracking, values, token });
 
           return {
             title,
@@ -81,7 +81,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.Ref<HTMLInput
         }),
       );
     }
-  }, [mode, suggestions, maxSuggestions, results, useClickTracking, tracking]);
+  }, [mode, suggestions, maxSuggestions, results, applyClickTracking, tracking]);
 
   useEffect(() => {
     if (!arraysEqual(lastItems.current, internalSuggestions)) {

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -19,7 +19,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useSearchUIContext } from '../../../ContextProvider';
-import { useClickTracking, usePosNegTracking } from '../../../hooks';
+import { applyClickTracking, applyPosNegTracking } from '../../../utils';
 import useResultStyles from './styles';
 import { ResultProps } from './types';
 
@@ -54,8 +54,13 @@ const Result = React.memo(
     } = props;
     const { t } = useTranslation('result');
     const { currency, language, ratingMax, tracking } = useSearchUIContext();
-    const { href, onClick: clickTrackingOnClick } = useClickTracking({ token, tracking, values, onClick: onClickProp });
-    const { onClick: posNegOnClick } = usePosNegTracking({
+    const { href, onClick: clickTrackingOnClick } = applyClickTracking({
+      token,
+      tracking,
+      values,
+      onClick: onClickProp,
+    });
+    const { onClick: posNegOnClick } = applyPosNegTracking({
       token,
       tracking,
       values,

--- a/packages/search-ui/src/Results/components/Result/types.ts
+++ b/packages/search-ui/src/Results/components/Result/types.ts
@@ -3,7 +3,7 @@ import { Token } from '@sajari/react-hooks';
 import { PosNegLocalStorageManager } from '@sajari/sdk-js';
 import * as React from 'react';
 
-import { UseClickTrackingParams } from '../../../hooks';
+import { ApplyClickTrackingParams } from '../../../utils';
 import { ResultsProps, ResultValues } from '../../types';
 
 interface Props extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | 'imageObjectFit'>, BoxProps {
@@ -14,7 +14,7 @@ interface Props extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | '
   /** Used to store pos tokens after click for later consumption */
   posNegLocalStorageManager: PosNegLocalStorageManager;
   /** Handle clicking a result */
-  onClick?: UseClickTrackingParams['onClick'];
+  onClick?: ApplyClickTrackingParams['onClick'];
   /** Display image or not */
   showImage?: boolean;
   /** Display variant images or not */

--- a/packages/search-ui/src/hooks/index.ts
+++ b/packages/search-ui/src/hooks/index.ts
@@ -1,4 +1,0 @@
-export { default as useClickTracking } from './useClickTracking';
-export * from './useClickTracking';
-export { default as usePosNegTracking } from './usePosNegTracking';
-export * from './usePosNegTracking';

--- a/packages/search-ui/src/utils/applyClickTracking.test.ts
+++ b/packages/search-ui/src/utils/applyClickTracking.test.ts
@@ -1,11 +1,11 @@
 import { ClickTracking } from '@sajari/react-hooks';
 
-import useClickTracking from './useClickTracking';
+import applyClickTracking from './applyClickTracking';
 
-describe('useClickTracking', () => {
+describe('applyClickTracking', () => {
   it('should work normally', () => {
     const onClickHandler = jest.fn();
-    const { href, onClick } = useClickTracking({
+    const { href, onClick } = applyClickTracking({
       token: { click: 'test.token' },
       tracking: new ClickTracking(),
       values: { _id: '12345', title: 'test.title', url: 'test.url' },

--- a/packages/search-ui/src/utils/applyClickTracking.ts
+++ b/packages/search-ui/src/utils/applyClickTracking.ts
@@ -3,14 +3,14 @@ import { isEmpty, isFunction, isString, isValidURL, noop } from '@sajari/react-s
 
 import { ResultValues } from '../Results/types';
 
-export interface UseClickTrackingParams {
+export interface ApplyClickTrackingParams {
   token: Token | undefined;
   tracking: ClickTracking | PosNegTracking | undefined;
   values: ResultValues;
   onClick?: ResultClickedFn;
 }
 
-function useClickTracking(params: UseClickTrackingParams) {
+function applyClickTracking(params: ApplyClickTrackingParams) {
   const { onClick, token, tracking, values } = params;
   const { url } = values;
 
@@ -46,4 +46,4 @@ function useClickTracking(params: UseClickTrackingParams) {
   };
 }
 
-export default useClickTracking;
+export default applyClickTracking;

--- a/packages/search-ui/src/utils/applyPosNegTracking.ts
+++ b/packages/search-ui/src/utils/applyPosNegTracking.ts
@@ -4,7 +4,7 @@ import { PosNegLocalStorageManager } from '@sajari/sdk-js';
 
 import { ResultValues } from '../Results/types';
 
-export interface UsePosNegTrackingParams {
+export interface ApplyPosNegTrackingParams {
   token: Token | undefined;
   tracking: ClickTracking | PosNegTracking | undefined;
   values: ResultValues;
@@ -12,7 +12,7 @@ export interface UsePosNegTrackingParams {
   posNegLocalStorageManager: PosNegLocalStorageManager;
 }
 
-function usePosNegTracking(params: UsePosNegTrackingParams) {
+function applyPosNegTracking(params: ApplyPosNegTrackingParams) {
   const { onClick, token, tracking, values, posNegLocalStorageManager } = params;
 
   if (!tracking || !(tracking instanceof PosNegTracking)) {
@@ -40,4 +40,4 @@ function usePosNegTracking(params: UsePosNegTrackingParams) {
   };
 }
 
-export default usePosNegTracking;
+export default applyPosNegTracking;

--- a/packages/search-ui/src/utils/index.ts
+++ b/packages/search-ui/src/utils/index.ts
@@ -1,0 +1,4 @@
+export { default as applyClickTracking } from './applyClickTracking';
+export * from './applyClickTracking';
+export { default as applyPosNegTracking } from './applyPosNegTracking';
+export * from './applyPosNegTracking';


### PR DESCRIPTION
# Even though the API is not exported to public, this is a breaking change since it renames the existing API
This PR renames the `useClickTracking` and `usePosNegTracking` hook to use the `apply` prefix instead, so:
- `useClickTracking` -> `applyClickTracking`
- `usePosNegTracking` -> `applyPosNegTracking`
We can consider keeping both the old and new API and have a plan for deprecation later on @wwalser 