### PR TITLE
fix: input does not accept HTML attributes

### DIFF
--- a/.changeset/sharp-seahorses-grab.md
+++ b/.changeset/sharp-seahorses-grab.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Fix `Input` doesn't accept HTML attributes like `name`.

--- a/packages/search-ui/src/Input/types.ts
+++ b/packages/search-ui/src/Input/types.ts
@@ -1,6 +1,6 @@
 import { ComboboxProps } from '@sajari/react-components';
 
-export interface InputProps<T>
+interface Props<T>
   extends Pick<
     ComboboxProps<T>,
     | 'placeholder'
@@ -15,6 +15,7 @@ export interface InputProps<T>
     | 'variant'
     | 'size'
     | 'autoFocus'
+    | 'name'
   > {
   mode?: ComboboxProps<T>['mode'] | 'instant';
   /* Sets how many autocomplete suggestions are shown in the box below the search input */
@@ -24,3 +25,7 @@ export interface InputProps<T>
   /** The number of characters needed to trigger a search */
   minimumCharacters?: number;
 }
+
+type HtmlAttributes<T> = Omit<React.InputHTMLAttributes<HTMLInputElement>, keyof Props<T>>;
+
+export interface InputProps<T = unknown> extends Props<T>, HtmlAttributes<T> {}


### PR DESCRIPTION
Fix `Input` doesn't accept HTML attributes like `name`. 

Also, fallback type param to `unknown` so we don't have to pass `any` when using the `InputProps` interface.