### PR TITLE
chore: ie11 support by working around lack of toString.call

### DIFF
--- a/.changeset/nice-bags-sip.md
+++ b/.changeset/nice-bags-sip.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-sdk-utils': patch
+---
+
+chore: ie11 support by working around lack of toString.call

--- a/packages/utils/src/assertion.ts
+++ b/packages/utils/src/assertion.ts
@@ -6,6 +6,15 @@ const getTag = (value: any) => {
     return value === undefined ? '[object Undefined]' : '[object Null]';
   }
 
+  // IE11 (remove if statement after end of life, July 2022)
+  if (!toString.call) {
+    try {
+      return value.toString();
+    } catch (err) {
+      return 'unknown';
+    }
+  }
+
   return toString.call(value);
 };
 


### PR DESCRIPTION
chore: ie11 support by working around lack of toString.call