### PR TITLE
chore: bump packages and require latest version of sdk-utils

### DIFF
--- a/.changeset/cyan-weeks-visit.md
+++ b/.changeset/cyan-weeks-visit.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+'@sajari/server': patch
+---
+
+chore: bump packages and require latest version of sdk-utils

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,7 @@
     "@react-aria/textfield": "^3.2.2",
     "@react-aria/utils": "^3.5.0",
     "@react-types/button": "^3.3.0",
-    "@sajari/react-sdk-utils": "^1.4.1",
+    "@sajari/react-sdk-utils": "^1.4.2",
     "aria-hidden": "^1.1.2",
     "body-scroll-lock": "^3.1.5",
     "classnames": "^2.2.6",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -29,7 +29,7 @@
     "@react-aria/utils": "3.5.0",
     "@sajari/react-components": "^1.12.0",
     "@sajari/react-hooks": "^3.3.0",
-    "@sajari/react-sdk-utils": "^1.4.1",
+    "@sajari/react-sdk-utils": "^1.4.2",
     "dayjs": "^1.10.5",
     "i18next": "19.8.7",
     "i18next-browser-languagedetector": "^6.0.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@sajari/react-hooks": "^3.1.1",
-    "@sajari/react-sdk-utils": "^1.4.1"
+    "@sajari/react-sdk-utils": "^1.4.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
chore: bump packages and require latest version of sdk-utils