### PR TITLE
fix: remove import/cycle eslint ignore

### DIFF
--- a/packages/hooks/src/ContextProvider/controllers/Pipeline.ts
+++ b/packages/hooks/src/ContextProvider/controllers/Pipeline.ts
@@ -3,7 +3,7 @@ import { isNullOrUndefined, isSSR, isString } from '@sajari/react-sdk-utils';
 import { Client } from '@sajari/sdk-js';
 
 import { EVENT_RESPONSE_UPDATED, EVENT_RESULT_CLICKED, EVENT_SEARCH_SENT } from '../events';
-import { ResultValues } from '../types';
+import type { ResultValues } from '../types';
 import { Analytics, GoogleAnalytics } from './analytics';
 import { CallbackFn, Listener, ListenerMap, UnlistenFn } from './Listener';
 import { Response } from './Response';

--- a/packages/hooks/src/ContextProvider/controllers/analytics/Analytics.ts
+++ b/packages/hooks/src/ContextProvider/controllers/analytics/Analytics.ts
@@ -9,7 +9,7 @@ import {
   EVENT_TRACKING_RESET,
 } from '../../events';
 import { CallbackFn, Listener, ListenerMap } from '../Listener';
-import { Pipeline } from '../Pipeline';
+import type { Pipeline } from '../Pipeline';
 import { Response } from '../Response';
 import { Tracking } from '../tracking';
 

--- a/packages/hooks/src/ContextProvider/controllers/analytics/DebugAnalytics.ts
+++ b/packages/hooks/src/ContextProvider/controllers/analytics/DebugAnalytics.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { EVENT_ANALYTICS_BODY_RESET, EVENT_ANALYTICS_PAGE_CLOSED, EVENT_ANALYTICS_RESULT_CLICKED } from '../../events';
-import { Analytics } from './Analytics';
+import type { Analytics } from './Analytics';
 
 export class DebugAnalytics {
   /**

--- a/packages/hooks/src/ContextProvider/controllers/analytics/GoogleAnalytics.ts
+++ b/packages/hooks/src/ContextProvider/controllers/analytics/GoogleAnalytics.ts
@@ -3,7 +3,7 @@ import { isFunction, isSSR } from '@sajari/react-sdk-utils';
 
 import { EVENT_ANALYTICS_BODY_RESET, EVENT_ANALYTICS_PAGE_CLOSED, EVENT_ANALYTICS_RESULT_CLICKED } from '../../events';
 import { UnlistenFn } from '../Listener';
-import { Analytics } from './Analytics';
+import type { Analytics } from './Analytics';
 
 enum GoogleAnalyticsObjects {
   UniversalAnalytics = '_ua',

--- a/packages/hooks/src/ContextProvider/controllers/analytics/index.ts
+++ b/packages/hooks/src/ContextProvider/controllers/analytics/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-cycle */
 export { Analytics } from './Analytics';
 export { DebugAnalytics } from './DebugAnalytics';
 export { GoogleAnalytics } from './GoogleAnalytics';

--- a/packages/hooks/src/ContextProvider/controllers/index.ts
+++ b/packages/hooks/src/ContextProvider/controllers/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-cycle */
 export { Analytics, DebugAnalytics, GoogleAnalytics } from './analytics';
 export { default as combineFilters } from './filters/combineFilters';
 export { default as FilterBuilder } from './filters/FilterBuilder';

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-cycle */
 /* eslint-disable react/jsx-no-target-blank */
 import { Box, Heading, Image, ImageProps, Link, Rating, Text } from '@sajari/react-components';
 import { ClickTracking } from '@sajari/react-hooks';

--- a/packages/search-ui/src/Results/components/TemplateResult/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResult/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-cycle */
 import { PropsWithAs } from '@sajari/react-sdk-utils';
 
 import { ResultValues } from '../../types';

--- a/packages/search-ui/src/Results/types.ts
+++ b/packages/search-ui/src/Results/types.ts
@@ -1,8 +1,7 @@
-/* eslint-disable import/no-cycle */
 import { BoxProps, ImageProps } from '@sajari/react-components';
 import { ResultValues } from '@sajari/react-hooks';
 
-import { TemplateResultProps } from './components/TemplateResult/types';
+import type { TemplateResultProps } from './components/TemplateResult/types';
 
 export type ResultTemplate = {
   html: string;


### PR DESCRIPTION
Using the `import type` feature of TypeScript
ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export