### PR TITLE
fix: clear container when toggling show variant image option

### DIFF
--- a/.changeset/afraid-items-obey.md
+++ b/.changeset/afraid-items-obey.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Clear the images container whenever the option changes so that old images won't stack up

--- a/packages/search-ui/src/Results/useProductImages.ts
+++ b/packages/search-ui/src/Results/useProductImages.ts
@@ -148,10 +148,14 @@ export function useProductImages(props: Props): UseProductImagesOutput {
 
   useEffect(() => {
     const { image } = values;
-    if (container && showVariantImage && isArray(image)) {
-      const style = document.createElement('style');
-      style.id = 'sj-result-template-default-style';
-      style.textContent = `
+    if (container) {
+      while (container.firstChild) {
+        container.removeChild(container.firstChild);
+      }
+      if (showVariantImage && isArray(image)) {
+        const style = document.createElement('style');
+        style.id = 'sj-result-template-default-style';
+        style.textContent = `
         [data-sj-variant-image]::before {
           padding-bottom: calc(100%);
           content: "";
@@ -159,13 +163,14 @@ export function useProductImages(props: Props): UseProductImagesOutput {
           height: 0px;
         }
       `;
-      document.head.appendChild(style);
-      const images = image.map(getCreateImageElementFunc(setActiveImageIndex));
-      images.forEach((img) => {
-        container.appendChild(img);
-      });
-    } else {
-      document.querySelector('#sj-result-template-default-style')?.remove();
+        document.head.appendChild(style);
+        const images = image.map(getCreateImageElementFunc(setActiveImageIndex));
+        images.forEach((img) => {
+          container.appendChild(img);
+        });
+      } else {
+        document.querySelector('#sj-result-template-default-style')?.remove();
+      }
     }
   }, [container, showVariantImage]);
 

--- a/packages/search-ui/src/Results/useProductImages.ts
+++ b/packages/search-ui/src/Results/useProductImages.ts
@@ -165,9 +165,11 @@ export function useProductImages(props: Props): UseProductImagesOutput {
       `;
         document.head.appendChild(style);
         const images = image.map(getCreateImageElementFunc(setActiveImageIndex));
+        const fragment = document.createDocumentFragment();
         images.forEach((img) => {
-          container.appendChild(img);
+          fragment.appendChild(img);
         });
+        container.appendChild(fragment);
       } else {
         document.querySelector('#sj-result-template-default-style')?.remove();
       }


### PR DESCRIPTION
Need to clear the images container when toggling the variant image option or the old images will stack up.