### PR TITLE
fix: render price logic when showing variant images

### DIFF
--- a/.changeset/small-fishes-crash.md
+++ b/.changeset/small-fishes-crash.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Fix render price logic when showing variant images

--- a/packages/search-ui/src/Results/useRenderPrice.ts
+++ b/packages/search-ui/src/Results/useRenderPrice.ts
@@ -17,13 +17,26 @@ export type UseRenderPriceOutput = {
 
 export function useRenderPrice({
   values,
-  activeImageIndex = 0,
+  activeImageIndex: activeImageIndexProp = 0,
   isOnSale,
   currency,
   language,
 }: Input): UseRenderPriceOutput {
-  const { price, salePrice, originalPrice } = values;
-  if (isEmpty(price)) return null;
+  const { price: priceProp, salePrice, originalPrice } = values;
+  let price = priceProp;
+  let activeImageIndex = activeImageIndexProp;
+
+  if (isEmpty(price) || isEmpty(priceProp)) return null;
+
+  const hasVariantImages = isArray(price[0]);
+
+  if (hasVariantImages && activeImageIndexProp === 0)
+    return { priceToDisplay: formatPrice(price[0], { currency, language }) };
+
+  if (hasVariantImages) {
+    activeImageIndex = activeImageIndexProp - 1;
+    price = priceProp.slice(1);
+  }
   const activePrice = isArray(price) ? price[activeImageIndex] ?? price : price;
   if (isEmpty(activePrice)) return null;
   let priceToDisplay: string;


### PR DESCRIPTION
This PR will add another variable called `isCurrentOnSale` this is different from `isOnSale` from that `isOnSale` will be true if at least one of the variant products is on sale. On the other hand, `isCurrentOnSale` is only of that variant product.