### PR TITLE
fix: input typeahead mode is broken

### DIFF
--- a/.changeset/silly-cups-matter.md
+++ b/.changeset/silly-cups-matter.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-components': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix input typeahead mode is broken.

--- a/packages/components/src/Combobox/components/Typeahead/index.tsx
+++ b/packages/components/src/Combobox/components/Typeahead/index.tsx
@@ -22,8 +22,9 @@ const Typeahead = () => {
     inputValue,
     disableDefaultStyles = false,
     customClassNames: { typeaheadClassName = '' },
+    size,
   } = useComboboxContext();
-  const styles = getStylesObject(useTypeaheadStyles(), disableDefaultStyles);
+  const styles = getStylesObject(useTypeaheadStyles({ size }), disableDefaultStyles);
   let typeaheadValue = '';
   let hiddenText = '&#8203;';
 

--- a/packages/components/src/Combobox/components/Typeahead/styles.ts
+++ b/packages/components/src/Combobox/components/Typeahead/styles.ts
@@ -1,9 +1,17 @@
 import { mapStyles } from '@sajari/react-sdk-utils';
 import tw from 'twin.macro';
 
-export function useTypeaheadStyles() {
+import { getInputSpacingStyles } from '../../styles';
+import { ComboboxSize } from '../../types';
+
+interface TypeaheadStylesProps {
+  size?: ComboboxSize;
+}
+
+export function useTypeaheadStyles(props: TypeaheadStylesProps) {
+  const { size } = props;
   const styles = {
-    container: [tw`text-gray-400`],
+    container: [tw`text-gray-400`, getInputSpacingStyles(size)],
     hidden: [tw`opacity-0`],
   };
 

--- a/packages/components/src/Combobox/context.tsx
+++ b/packages/components/src/Combobox/context.tsx
@@ -2,7 +2,7 @@
 import { createContext } from '@sajari/react-sdk-utils';
 import { PropGetters } from 'downshift';
 
-import { ComboboxCustomClassNames, ComboboxMode, ComboboxProps } from './types';
+import { ComboboxCustomClassNames, ComboboxMode, ComboboxProps, ComboboxSize } from './types';
 
 interface ComboboxContextProps<T = any> {
   mode: ComboboxMode;
@@ -25,6 +25,7 @@ interface ComboboxContextProps<T = any> {
   customClassNames: ComboboxCustomClassNames;
   inAttachMode?: boolean;
   inputElement?: React.RefObject<HTMLInputElement>;
+  size?: ComboboxSize;
 }
 
 const [ComboboxContextProvider, useComboboxContext] = createContext<ComboboxContextProps>({

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -236,6 +236,7 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     customClassNames: rest,
     inAttachMode,
     inputElement,
+    size,
   };
 
   const handleVoiceInput = (input: string) => {

--- a/packages/components/src/Combobox/styles.ts
+++ b/packages/components/src/Combobox/styles.ts
@@ -3,7 +3,7 @@ import { inferStylesObjectKeys, mapStyles } from '@sajari/react-sdk-utils';
 import tw, { TwStyle } from 'twin.macro';
 
 import { useFocusRingStyles } from '../hooks';
-import { ComboboxProps } from './types';
+import { ComboboxProps, ComboboxSize } from './types';
 
 interface UseComboboxStylesProps {
   size: ComboboxProps<any>['size'];
@@ -12,18 +12,37 @@ interface UseComboboxStylesProps {
   variant: ComboboxProps<any>['variant'];
 }
 
+export function getInputSpacingStyles(size?: ComboboxSize) {
+  switch (size) {
+    case 'sm':
+      return tw`text-sm pl-8`;
+
+    case '2xl':
+      return tw`pl-9 text-2xl`;
+
+    case 'xl':
+      return tw`pl-10 text-xl`;
+
+    case 'lg':
+      return tw`text-lg pl-10`;
+
+    case 'md':
+    default:
+      return tw`pl-9`;
+  }
+}
+
 export function useComboboxStyles(props: UseComboboxStylesProps) {
   const { size, voiceEnabled, loading, variant } = props;
   const { focusProps, focusRingStyles } = useFocusRingStyles();
   const containerStyles: TwStyle[] = [];
-  const inputStyles: TwStyle[] = [];
   const iconContainerStyles: TwStyle[] = [tw`absolute inset-y-0 flex items-center space-x-2 text-gray-400`];
   const iconSearchStyles: TwStyle[] = [];
+  const inputStyles = getInputSpacingStyles(size);
 
   switch (size) {
     case 'sm':
       containerStyles.push(tw`py-1`);
-      inputStyles.push(tw`text-sm pl-8`);
 
       if (loading && voiceEnabled) {
         containerStyles.push(tw`pr-13`);
@@ -36,7 +55,6 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
 
     case '2xl':
       containerStyles.push(tw`py-4`);
-      inputStyles.push(tw`pl-9 text-2xl`);
 
       if (loading && voiceEnabled) {
         containerStyles.push(tw`pr-15`);
@@ -50,7 +68,6 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
 
     case 'xl':
       containerStyles.push(tw`py-3.5`);
-      inputStyles.push(tw`pl-10 text-xl`);
 
       if (loading && voiceEnabled) {
         containerStyles.push(tw`pr-15`);
@@ -64,7 +81,6 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
 
     case 'lg':
       containerStyles.push(tw`py-3`);
-      inputStyles.push(tw`text-lg pl-10`);
 
       if (loading && voiceEnabled) {
         containerStyles.push(tw`pr-15`);
@@ -77,8 +93,6 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
 
     case 'md':
     default:
-      inputStyles.push(tw`pl-9`);
-
       if (loading && voiceEnabled) {
         containerStyles.push(tw`pr-14`);
       } else if (loading || voiceEnabled) {
@@ -91,13 +105,13 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
 
   const styles = inferStylesObjectKeys({
     container: [tw`relative`],
-    inputContainer: [tw`form-input`, tw`relative text-base transition-all duration-150`, ...containerStyles],
+    inputContainer: [tw`form-input`, tw`relative text-base transition-all duration-150 px-0`, ...containerStyles],
     iconContainerLeft: [...iconContainerStyles, tw`left-0`],
     iconContainerRight: [...iconContainerStyles, tw`right-0`],
     input: [
       tw`form-input`,
       tw`absolute inset-0 w-full h-full bg-transparent border-0 focus:border-0 outline-none focus:outline-none shadow-none focus:shadow-none font-inherit m-0 p-0 box-border`,
-      ...inputStyles,
+      inputStyles,
       ` &::-ms-clear,
         &::-ms-reveal {
           display: none;

--- a/packages/components/src/Combobox/types.ts
+++ b/packages/components/src/Combobox/types.ts
@@ -45,6 +45,8 @@ export interface ComboboxCustomClassNames {
   typeaheadClassName?: string;
 }
 
+export type ComboboxSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
 interface Props<T> {
   /** The mode for the combobox to operate */
   mode?: ComboboxMode;
@@ -72,7 +74,7 @@ interface Props<T> {
   /** The typeahead completion value */
   completion?: string;
   /** The size of the combobox input */
-  size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+  size?: ComboboxSize;
   /** Whether to show tips in the dropdown on how to navigate the options */
   showDropdownTips?: boolean;
   /** Whether to show the "Powered by Sajari" in the dropdown */


### PR DESCRIPTION
Fix typeahead text overlaps the input text.

![image](https://user-images.githubusercontent.com/12707960/133052943-ce41916d-00fe-42d6-a4a5-bedd1d2cc49d.png)

Note that there is a "line-height" issue if the input size is greater than `xl` due to the absolute position of the input. Fixing the issue was time-consuming for me so I would suggest we move forward with the PR since the 2xl input is not commonly used and I will propose another PR to fix it later. 

![image](https://user-images.githubusercontent.com/12707960/133053246-7b7bfeee-83ee-4ad3-9494-d5aacfc92eea.png)
