### PR TITLE
fix: reset button missing margin top

### DIFF
--- a/.changeset/nasty-eels-relate.md
+++ b/.changeset/nasty-eels-relate.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Recover margin top for the reset button in `Message` component.

--- a/packages/search-ui/src/Results/components/Message/index.tsx
+++ b/packages/search-ui/src/Results/components/Message/index.tsx
@@ -32,7 +32,7 @@ const Message = (props: MessageProps) => {
   }, []);
 
   const renderResetButton = showReset ? (
-    <Button css={styles.resetButton} appearance="primary" size="sm" onClick={reset}>
+    <Button css={styles.resetButton} appearance="primary" onClick={reset}>
       {t('reset')}
     </Button>
   ) : null;

--- a/packages/search-ui/src/Results/components/Message/styles.ts
+++ b/packages/search-ui/src/Results/components/Message/styles.ts
@@ -10,7 +10,7 @@ export default function useMessageStyles() {
     errorHeading: [tw`text-red-500`],
     errorText: [tw`text-gray-500`],
     defaultText: [tw`text-gray-500`],
-    resetButton: [tw`mt-4 m-0`],
+    resetButton: [tw`mt-4`],
   };
 
   return mapStyles(styles);


### PR DESCRIPTION
Recover margin-top for the reset button in `Message` component.

![image](https://user-images.githubusercontent.com/12707960/133619359-32566388-e608-4401-98cc-2326a4f7d29c.png)

Also, make the button bigger. See:

![image](https://user-images.githubusercontent.com/12707960/133619468-b6973773-f6c1-4057-a4b1-9355ffd58540.png)
