### PR TITLE
fix: move behaviour implementation of autocomplete out of input to enable better form management

### DIFF
--- a/.changeset/smart-wolves-arrive.md
+++ b/.changeset/smart-wolves-arrive.md
@@ -1,0 +1,9 @@
+---
+'@sajari/react-components': minor
+'@sajari/react-hooks': minor
+'@sajari/react-search-ui': minor
+'@sajari/server': patch
+'@sajari/react-sdk-utils': patch
+---
+
+fix: bug fix for handling of redirect returned in autocomplete pipelines

--- a/packages/components/src/Combobox/index.tsx
+++ b/packages/components/src/Combobox/index.tsx
@@ -17,7 +17,10 @@ import ComboboxContextProvider from './context';
 import { useComboboxStyles } from './styles';
 import { ComboboxProps, ResultItem } from './types';
 
-const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps<T>, ref: React.Ref<HTMLInputElement>) {
+const Combobox = React.forwardRef(function ComboboxInner<T>(
+  props: ComboboxProps<T>,
+  ref: React.ForwardedRef<HTMLInputElement>,
+) {
   const {
     mode = 'standard',
     label,
@@ -272,6 +275,15 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
     spellCheck: 'false',
     inputMode: 'search',
     ref: (node) => {
+      // necessary because of forwarded ref and inner ref
+      if (ref) {
+        if (typeof ref === 'function') {
+          ref(node);
+        } else {
+          // eslint-disable-next-line no-param-reassign
+          ref.current = node;
+        }
+      }
       inputRef.current = node;
     },
     onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
@@ -378,7 +390,6 @@ const Combobox = React.forwardRef(function ComboboxInner<T>(props: ComboboxProps
             <Typeahead />
 
             <Box
-              ref={ref}
               as="input"
               css={styles.input}
               {...mergeProps(inputProps, focusProps)}


### PR DESCRIPTION
There was a problem where the wrapping form would be submitted before the location was changed by the input.

To fix, I've moved the redirect logic out of input and instead put it into widgets where we can better manage form submission.