### PR TITLE
Don't send unchanged range filter values

### DIFF
--- a/.changeset/popular-pumas-boil.md
+++ b/.changeset/popular-pumas-boil.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+'@sajari/server': patch
+---
+
+fix: avoid sending range filter when min and max values are set to the min and max of the collection

--- a/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/RangeFilterBuilder.ts
@@ -117,7 +117,7 @@ export default class RangeFilterBuilder {
     }
   }
 
-  public getMinMax() {
+  public getMinMax(): [number, number] {
     return [this.min, this.max];
   }
 
@@ -129,7 +129,8 @@ export default class RangeFilterBuilder {
    * Builds up the filter string from the current state.
    */
   public filter() {
-    if (!this.range) {
+    const minMax = this.getMinMax();
+    if (!this.range || (this.range[0] === minMax[0] && this.range[1] === minMax[1])) {
       return '';
     }
 

--- a/packages/hooks/src/ContextProvider/controllers/filters/test/RangeFilterBuilder.test.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/test/RangeFilterBuilder.test.ts
@@ -51,6 +51,8 @@ describe('RangeFilterBuilder', () => {
   it('filter and set', () => {
     priceFilter.set(null);
     expect(priceFilter.filter()).toBe('');
+    priceFilter.set(priceFilter.getMinMax());
+    expect(priceFilter.filter()).toBe('');
     priceFilter.set([0, 100]);
     expect(priceFilter.filter()).toBe('price >= 0 AND price <= 100');
     priceFilter.set([50, 200]);

--- a/packages/hooks/src/ContextProvider/controllers/filters/test/combineFilters.test.ts
+++ b/packages/hooks/src/ContextProvider/controllers/filters/test/combineFilters.test.ts
@@ -107,7 +107,14 @@ describe('combineFilters', () => {
 
   it('filter', () => {
     expect(combination.filter()).toBe(
-      'ARRAY_MATCH((color = "red") AND (size = "small")) AND (brand = "Apple") AND (price >= 200) AND (popularity >= 100 AND popularity <= 600) AND (rating >= 1 AND rating <= 5)',
+      'ARRAY_MATCH((color = "red") AND (size = "small")) AND (brand = "Apple") AND (price >= 200) AND (popularity >= 100 AND popularity <= 600)',
+    );
+  });
+
+  it('filter after rating range change', () => {
+    ratingRangeFilter.set([2, 5]);
+    expect(combination.filter()).toBe(
+      'ARRAY_MATCH((color = "red") AND (size = "small")) AND (brand = "Apple") AND (price >= 200) AND (popularity >= 100 AND popularity <= 600) AND (rating >= 2 AND rating <= 5)',
     );
   });
 


### PR DESCRIPTION
fix: avoid sending range filter when min and max values are set to the min and max of the collection