### PR TITLE
fix: add resize observer for custom template

### DIFF
--- a/.changeset/late-actors-destroy.md
+++ b/.changeset/late-actors-destroy.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Add ResizeObserver for custom templates

--- a/docs/pages/search-ui/results.mdx
+++ b/docs/pages/search-ui/results.mdx
@@ -212,17 +212,9 @@ function Example() {
 `,
   };
 
-  const customClassNames = {
-    results: {
-      template: {
-        container: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6',
-      },
-    },
-  };
-
   return (
     <SearchProvider
-      customClassNames={customClassNames}
+      viewType="grid"
       search={{
         pipeline,
         fields: new FieldDictionary({
@@ -236,7 +228,10 @@ function Example() {
       }}
       searchOnLoad
     >
-      <Results resultTemplate={template} />
+      <div className="flex flex-col items-center space-y-4">
+        <ViewType />
+        <Results resultTemplate={template} />
+      </div>
     </SearchProvider>
   );
 }

--- a/packages/search-ui/src/Results/components/BannerItem/index.tsx
+++ b/packages/search-ui/src/Results/components/BannerItem/index.tsx
@@ -5,7 +5,7 @@ import { useSearchUIContext } from '../../../ContextProvider';
 import { useBannerStyle } from './styles';
 import { BannerItemProps } from './types';
 
-const BannerItem = ({ banner, templateMode = false, numberOfCols = 1 }: BannerItemProps) => {
+const BannerItem = ({ banner, numberOfCols = 1 }: BannerItemProps) => {
   const { disableDefaultStyles = false, customClassNames, tracking } = useSearchUIContext();
   const { title, description, targetUrl, imageUrl, width, height, textColor } = banner;
   const styles = getStylesObject(useBannerStyle({ banner }), disableDefaultStyles);
@@ -17,8 +17,7 @@ const BannerItem = ({ banner, templateMode = false, numberOfCols = 1 }: BannerIt
         styles.container,
         customClassNames.banners?.container,
         {
-          // In template mode (banners rendered in result template), the `numberOfCols` variable is always 0 because we aren't using ResizeObserver to watch the width anymore
-          gridColumnEnd: `span ${templateMode ? width : Math.min(width ?? 1, numberOfCols)}`,
+          gridColumnEnd: `span ${Math.min(width ?? 1, numberOfCols)}`,
           gridRowEnd: `span ${height}`,
         },
       ]}

--- a/packages/search-ui/src/Results/components/BannerItem/types.ts
+++ b/packages/search-ui/src/Results/components/BannerItem/types.ts
@@ -3,7 +3,6 @@ import { Banner } from '@sajari/sdk-js';
 import { ColumnValue } from '../../types';
 
 export interface BannerItemProps {
-  templateMode?: boolean;
   banner: Banner;
   numberOfCols?: ColumnValue;
 }

--- a/packages/search-ui/src/Results/components/TemplateResults/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResults/index.tsx
@@ -11,7 +11,7 @@ import { Result, TemplateResultsProps } from './types';
 
 const TemplateResults = (props: TemplateResultsProps) => {
   const { customClassNames } = useSearchUIContext();
-  const { results, banners, resultTemplate, resultContainerTemplateElement, ...rest } = props;
+  const { results, banners, resultTemplate, resultContainerTemplateElement, numberOfCols, ...rest } = props;
   // Get the keys of a result, using Set to eliminate dups
   const keys = Array.from(
     results
@@ -44,7 +44,7 @@ const TemplateResults = (props: TemplateResultsProps) => {
       ) : null}
       {list.map((item, i) => {
         if (isBanner(item)) {
-          return <BannerItem key={`banner-${item.id}`} templateMode banner={item} />;
+          return <BannerItem key={`banner-${item.id}`} banner={item} numberOfCols={numberOfCols} />;
         }
 
         return (

--- a/packages/search-ui/src/Results/components/TemplateResults/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResults/index.tsx
@@ -11,7 +11,15 @@ import { Result, TemplateResultsProps } from './types';
 
 const TemplateResults = (props: TemplateResultsProps) => {
   const { customClassNames } = useSearchUIContext();
-  const { results, banners, resultTemplate, resultContainerTemplateElement, numberOfCols, ...rest } = props;
+  const {
+    results,
+    banners,
+    resultTemplate,
+    resultContainerTemplateElement,
+    numberOfCols,
+    containerStyle,
+    ...rest
+  } = props;
   // Get the keys of a result, using Set to eliminate dups
   const keys = Array.from(
     results
@@ -33,7 +41,7 @@ const TemplateResults = (props: TemplateResultsProps) => {
   const list = useMemo(() => mergeBannersWithResults<Result>(banners, results || []), [banners, results]);
 
   return (
-    <div className={customClassNames.results?.template?.container}>
+    <div css={containerStyle} className={customClassNames.results?.template?.container}>
       {checkValidResultTemplate(resultTemplate) && resultTemplate.css ? (
         // We inject here (once) instead of mutliple times in each result component
         <Global

--- a/packages/search-ui/src/Results/components/TemplateResults/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResults/types.ts
@@ -1,3 +1,4 @@
+import { SerializedStyles } from '@emotion/core';
 import type { ResultValues, Token } from '@sajari/react-hooks';
 import { Banner } from '@sajari/sdk-js';
 
@@ -13,6 +14,7 @@ interface Props extends Pick<ResultsProps, 'resultContainerTemplateElement' | 's
   results: Array<Result>;
   banners: Banner[];
   numberOfCols: ColumnValue;
+  containerStyle?: SerializedStyles;
 }
 
 export type TemplateResultsProps = Props;

--- a/packages/search-ui/src/Results/components/TemplateResults/types.ts
+++ b/packages/search-ui/src/Results/components/TemplateResults/types.ts
@@ -1,7 +1,7 @@
 import type { ResultValues, Token } from '@sajari/react-hooks';
 import { Banner } from '@sajari/sdk-js';
 
-import type { ResultsProps, ResultTemplate } from '../../types';
+import type { ColumnValue, ResultsProps, ResultTemplate } from '../../types';
 
 export type Result = {
   values: ResultValues;
@@ -12,6 +12,7 @@ interface Props extends Pick<ResultsProps, 'resultContainerTemplateElement' | 's
   resultTemplate: ResultTemplate;
   results: Array<Result>;
   banners: Banner[];
+  numberOfCols: ColumnValue;
 }
 
 export type TemplateResultsProps = Props;

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -122,13 +122,16 @@ const Results = (props: ResultsProps) => {
         FallbackComponent={TemplateErrorMessage}
         resetKeys={[`${resultTemplate.html}${resultTemplate.css}`]}
       >
-        <TemplateResults
-          showVariantImage={rest.showVariantImage}
-          results={results}
-          banners={renderBanners}
-          resultTemplate={resultTemplate}
-          resultContainerTemplateElement={resultContainerTemplateElement}
-        />
+        <ResizeObserver onResize={(rect) => setWidth(rect.width)}>
+          <TemplateResults
+            numberOfCols={numberOfCols}
+            showVariantImage={rest.showVariantImage}
+            results={results}
+            banners={renderBanners}
+            resultTemplate={resultTemplate}
+            resultContainerTemplateElement={resultContainerTemplateElement}
+          />
+        </ResizeObserver>
       </ErrorBoundary>
     );
   }

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -1,7 +1,6 @@
 import { ResizeObserver } from '@sajari/react-components';
 import { usePagination, useQuery, useSearchContext } from '@sajari/react-hooks';
 import { escapeHTML, getStylesObject, isEmpty, isNullOrUndefined } from '@sajari/react-sdk-utils';
-import { Banner } from '@sajari/sdk-js';
 import * as React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
@@ -130,6 +129,7 @@ const Results = (props: ResultsProps) => {
             banners={renderBanners}
             resultTemplate={resultTemplate}
             resultContainerTemplateElement={resultContainerTemplateElement}
+            containerStyle={styles.container}
           />
         </ResizeObserver>
       </ErrorBoundary>


### PR DESCRIPTION
This PR wrap the custom result template container with ResizeObserver (similar to the normal `Result` component). The reason is to get rid of extra responsive CSS that we have to inject along with the code snippet and to provide responsive support for banners.