### PR TITLE
fix: banner should not expand row height

### DIFF
--- a/.changeset/hot-files-hang.md
+++ b/.changeset/hot-files-hang.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Banner should not increase the row height

--- a/packages/search-ui/src/Results/components/BannerItem/index.tsx
+++ b/packages/search-ui/src/Results/components/BannerItem/index.tsx
@@ -22,27 +22,25 @@ const BannerItem = ({ banner, templateMode = false, numberOfCols = 1 }: BannerIt
         },
       ]}
     >
-      <Link href={targetUrl} css={styles.imageContainer}>
-        <img src={imageUrl} css={styles.image} alt="" loading="lazy" />
-        {title || description ? (
-          <Box css={styles.textContainer}>
-            {title ? (
-              <Heading
-                as="h2"
-                className={customClassNames.banners?.heading}
-                css={[{ color: textColor }, styles.heading]}
-              >
-                {title}
-              </Heading>
-            ) : null}
-            {description ? (
-              <Text className={customClassNames.banners?.description} css={[{ color: textColor }, styles.description]}>
-                {description}
-              </Text>
-            ) : null}
-          </Box>
-        ) : null}
-      </Link>
+      <Box css={styles.imageContainer}>
+        <Link href={targetUrl} css={styles.link}>
+          <img src={imageUrl} css={styles.image} alt="" loading="lazy" />
+        </Link>
+      </Box>
+      {title || description ? (
+        <Box css={styles.textContainer}>
+          {title ? (
+            <Heading as="h2" className={customClassNames.banners?.heading} css={[{ color: textColor }, styles.heading]}>
+              {title}
+            </Heading>
+          ) : null}
+          {description ? (
+            <Text className={customClassNames.banners?.description} css={[{ color: textColor }, styles.description]}>
+              {description}
+            </Text>
+          ) : null}
+        </Box>
+      ) : null}
     </Box>
   );
 };

--- a/packages/search-ui/src/Results/components/BannerItem/styles.ts
+++ b/packages/search-ui/src/Results/components/BannerItem/styles.ts
@@ -7,16 +7,24 @@ interface Props {
 }
 
 export const useBannerStyle = ({ banner }: Props) => {
-  const { textPosition } = banner;
+  const { textPosition, height = 1 } = banner;
 
   const styles = {
-    container: [tw`relative flex justify-center items-center overflow-hidden rounded-lg`],
+    container: [tw`relative flex justify-center overflow-hidden rounded-lg`],
     textContainer: [tw`absolute top-0 left-0 flex flex-col w-full h-full p-6`],
-    imageContainer: [tw`w-full h-full`],
+    imageContainer: [tw`w-full`],
     image: [tw`flex w-full h-full object-cover rounded-lg`],
     heading: [tw`max-w-md text-2xl`],
     description: [tw`max-w-md text-sm`],
   };
+
+  if (height > 1) {
+    styles.container.push(tw`items-center`);
+    styles.imageContainer.push(tw`h-full`);
+  } else {
+    styles.container.push(tw`items-start`);
+    styles.imageContainer.push(tw`max-h-0`);
+  }
 
   switch (textPosition) {
     case TextPosition.TopLeft:

--- a/packages/search-ui/src/Results/components/BannerItem/styles.ts
+++ b/packages/search-ui/src/Results/components/BannerItem/styles.ts
@@ -8,11 +8,11 @@ interface Props {
 
 export const useBannerStyle = ({ banner }: Props) => {
   const { textPosition, height = 1 } = banner;
-
   const styles = {
     container: [tw`relative flex justify-center overflow-hidden rounded-lg`],
     textContainer: [tw`absolute top-0 left-0 flex flex-col w-full h-full p-6`],
-    imageContainer: [tw`w-full`],
+    link: [tw`w-full`],
+    imageContainer: [tw`absolute w-full h-full`],
     image: [tw`flex w-full h-full object-cover rounded-lg`],
     heading: [tw`max-w-md text-2xl`],
     description: [tw`max-w-md text-sm`],
@@ -20,10 +20,10 @@ export const useBannerStyle = ({ banner }: Props) => {
 
   if (height > 1) {
     styles.container.push(tw`items-center`);
-    styles.imageContainer.push(tw`h-full`);
+    styles.link.push(tw`h-full`);
   } else {
     styles.container.push(tw`items-start`);
-    styles.imageContainer.push(tw`max-h-0`);
+    styles.link.push(tw`max-h-0`);
   }
 
   switch (textPosition) {


### PR DESCRIPTION
This should fix the issue where the banner height is larger than the row's items height and therefore expanding the row height (see below)
<img width="1203" alt="Screen Shot 2022-02-28 at 11 41 50" src="https://user-images.githubusercontent.com/25856620/155925555-68ac27a8-f52f-4e73-b9a2-b9a8c0606a3a.png">

After the fix it should look like this
<img width="1230" alt="Screen Shot 2022-02-28 at 11 31 01" src="https://user-images.githubusercontent.com/25856620/155925641-c4f367d2-ef65-40f2-8068-4e80a114acb9.png">

However, when the banner's height is smaller than the item's height then the following happens (the banner doesn't span all the full height), maybe @zlatanpham or @chidojiro would have an idea.
<img width="1186" alt="Screen Shot 2022-02-28 at 11 42 57" src="https://user-images.githubusercontent.com/25856620/155925756-d22bc563-dcbe-48a0-aae4-9830ed9ac765.png">