### PR TITLE
fix: remove unwanted resetFilters from autocomplete search

### DIFF
--- a/.changeset/popular-clouds-learn.md
+++ b/.changeset/popular-clouds-learn.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Remove `resetFilters` when calling autocomplete search. This trigger of the method is not only unnecessary, but it also introduces a mess in SearchContext to override the input value.

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -75,10 +75,6 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
   const searchAutocomplete = useCallback(
     (value: string) => {
       if (value.length >= minimumCharacters) {
-        if (!retainFilters) {
-          resetFilters();
-        }
-
         searchAutocompleteFunc(value);
       }
     },


### PR DESCRIPTION
Remove `resetFilters` when calling autocomplete search. This trigger of the method is not only unnecessary, but it also introduces a mess in SearchContext to override the input value.

https://search-io.atlassian.net/browse/SF-705