### PR TITLE
fix: performance issue on results

### DIFF
--- a/.changeset/little-dolphins-worry.md
+++ b/.changeset/little-dolphins-worry.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+fix: performance issue on results

--- a/packages/search-ui/src/ContextProvider/index.tsx
+++ b/packages/search-ui/src/ContextProvider/index.tsx
@@ -5,9 +5,9 @@ import { LiveAnnouncer } from 'react-aria-live';
 import { I18nextProvider } from 'react-i18next';
 
 import i18n from '../i18n';
-import { ContextProviderValues, ResultViewType, SearchUIContextProviderValues } from './types';
+import { ContextProviderValues, Language, ResultViewType, SearchUIContextProviderValues } from './types';
 
-const [Provider, useSearchUIContext] = createContext<Required<SearchUIContextProviderValues> & { language?: string }>({
+const [Provider, useSearchUIContext] = createContext<Required<SearchUIContextProviderValues> & Language>({
   strict: true,
   name: 'PipelineContext',
 });

--- a/packages/search-ui/src/ContextProvider/types.ts
+++ b/packages/search-ui/src/ContextProvider/types.ts
@@ -131,6 +131,8 @@ export interface SearchUIContextProviderValues {
   };
 }
 
+export type Language = { language?: string };
+
 export interface ContextProviderValues
   extends SearchProviderValues,
     ThemeProviderProps,

--- a/packages/search-ui/src/Results/components/Result/index.test.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.test.tsx
@@ -17,6 +17,9 @@ const customRender = (ui: React.ReactElement, props: ContextProviderValues) => {
   return render(<ContextProvider {...props}>{ui}</ContextProvider>);
 };
 
+const mockRatingMax = 5;
+const mockCurrency = 'USD';
+
 describe('Result', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -26,17 +29,33 @@ describe('Result', () => {
   });
 
   it('renders the correct link', () => {
-    customRender(<Result result={{ values: resultValues }} />, {
-      search: { pipeline: eventTrackingPipeline },
-    });
+    customRender(
+      <Result
+        tracking={eventTrackingPipeline.getTracking()}
+        ratingMax={mockRatingMax}
+        currency={mockCurrency}
+        result={{ values: resultValues }}
+      />,
+      {
+        search: { pipeline: eventTrackingPipeline },
+      },
+    );
     expect(screen.getByText(resultValues.title).closest('a')).toHaveAttribute('href', resultValues.url);
   });
 
   it('calls onResultClick on click', () => {
     const onResultClickSpy = jest.spyOn(eventTrackingPipeline.getTracking(), 'onResultClick');
-    customRender(<Result result={{ values: resultValues }} />, {
-      search: { pipeline: eventTrackingPipeline },
-    });
+    customRender(
+      <Result
+        tracking={eventTrackingPipeline.getTracking()}
+        ratingMax={mockRatingMax}
+        currency={mockCurrency}
+        result={{ values: resultValues }}
+      />,
+      {
+        search: { pipeline: eventTrackingPipeline },
+      },
+    );
     fireEvent.click(screen.getByText(resultValues.title));
     expect(onResultClickSpy).toHaveBeenCalledWith(resultValues, undefined);
   });

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -15,7 +15,6 @@ import utc from 'dayjs/plugin/utc';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useSearchUIContext } from '../../../ContextProvider';
 import { useProductStatus } from '../../useProductStatus';
 import { useRenderPrice } from '../../useRenderPrice';
 import useResultStyles from './styles';
@@ -47,10 +46,13 @@ const Result = React.memo(
       showStatus: showStatusProp = false,
       openNewTab = false,
       isPinned,
+      language,
+      currency,
+      ratingMax,
+      tracking,
       ...rest
     } = props;
     const { t } = useTranslation('result');
-    const { currency, language, ratingMax, tracking } = useSearchUIContext();
     const href = tracking.getResultHref(values, token);
     const onClick = () => tracking.onResultClick(values, token);
     const mouseDownHandler = (e: React.MouseEvent<HTMLElement>) => {

--- a/packages/search-ui/src/Results/components/Result/types.ts
+++ b/packages/search-ui/src/Results/components/Result/types.ts
@@ -2,9 +2,14 @@ import { BoxProps } from '@sajari/react-components';
 import type { Token } from '@sajari/react-hooks';
 import * as React from 'react';
 
+import { Language, SearchUIContextProviderValues } from '../../../ContextProvider/types';
 import { ResultsProps, ResultValues } from '../../types';
 
-interface Props extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | 'imageObjectFit'>, BoxProps {
+interface Props
+  extends Pick<ResultsProps, 'appearance' | 'imageAspectRatio' | 'imageObjectFit'>,
+    BoxProps,
+    Pick<Required<SearchUIContextProviderValues>, 'currency' | 'ratingMax' | 'tracking'>,
+    Language {
   /** Search result values */
   result: { values: ResultValues; token?: Token };
   /** Open the result link in a new tab */

--- a/packages/search-ui/src/Results/index.tsx
+++ b/packages/search-ui/src/Results/index.tsx
@@ -21,7 +21,16 @@ const Results = (props: ResultsProps) => {
   const results = React.useMemo(() => (rawResults ? mapResultFields<ResultValues>(rawResults, fields) : undefined), [
     rawResults,
   ]);
-  const { disableDefaultStyles = false, customClassNames, viewType, setViewType } = useSearchUIContext();
+  const {
+    disableDefaultStyles = false,
+    customClassNames,
+    viewType,
+    setViewType,
+    currency,
+    tracking,
+    ratingMax,
+    language,
+  } = useSearchUIContext();
   const { query } = useQuery();
   const {
     defaultAppearance,
@@ -166,6 +175,10 @@ const Results = (props: ResultsProps) => {
             newArrivalStatusClassName={customClassNames.results?.newArrivalStatus}
             openNewTab={openNewTab}
             isPinned={item.promotionPinned}
+            currency={currency}
+            ratingMax={ratingMax}
+            language={language}
+            tracking={tracking}
             {...rest}
           />
         );


### PR DESCRIPTION
resolve: https://search-io.atlassian.net/jira/software/projects/SF/boards/29?selectedIssue=SF-641

diagnose: rerenders happen so many times that makes the even loop busy and slow to process input events

solution: make items of Results independent from any context