### PR TITLE
chore(deps): correct react peer deps to be >=16.8.0

### DIFF
--- a/.changeset/many-jokes-design.md
+++ b/.changeset/many-jokes-design.md
@@ -1,0 +1,9 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+'@sajari/server': patch
+'@sajari/react-sdk-utils': patch
+---
+
+Correct React peer dependency versioning

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "dependencies": {
     "@popperjs/core": "^2.9.2",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,8 +18,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "dependencies": {
     "@sajari/react-sdk-utils": "^1.6.2",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "dependencies": {
     "@react-aria/utils": "3.5.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "dependencies": {
     "@sajari/react-hooks": "^3.7.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,7 +22,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "dependencies": {
     "@emotion/core": "^10.1.1",


### PR DESCRIPTION
Fixes this sort of thing:
```
$ npm i @sajari/react-search-ui --save
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: tw-test@0.1.0
npm ERR! Found: react@17.0.2
npm ERR! node_modules/react
npm ERR!   react@"^17.0.2" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.0" from @sajari/react-search-ui@4.13.1
npm ERR! node_modules/@sajari/react-search-ui
npm ERR!   @sajari/react-search-ui@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/jberry/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jberry/.npm/_logs/2022-03-21T01_31_06_353Z-debug-0.log
```