### PR TITLE
fix: enter behavior in input

### DIFF
--- a/.changeset/thick-bags-bake.md
+++ b/.changeset/thick-bags-bake.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Set the input to readonly instead of blurring focus after the Enter key has been pressed

--- a/packages/search-ui/src/Input/index.test.tsx
+++ b/packages/search-ui/src/Input/index.test.tsx
@@ -124,4 +124,40 @@ describe('Input', () => {
       undefined,
     );
   });
+
+  it('set the input to readonly after Enter key and remove it after it has done searching', async () => {
+    customRender(<Input data-testid="mysearch" />, {
+      search: { pipeline: eventTrackingPipeline },
+    });
+    const input = screen.getByTestId<HTMLInputElement>('mysearch');
+    const setAttributeSpy = jest.spyOn(input, 'setAttribute');
+    const removeAttributeSpy = jest.spyOn(input, 'removeAttribute');
+
+    input.focus();
+    user.keyboard('television{Enter}');
+    await waitFor(() => expect(input.attributes.getNamedItem('readonly')?.value).toBe(''));
+    await waitFor(() => expect(input.attributes.getNamedItem('readonly')).toBeNull());
+
+    expect(setAttributeSpy).toHaveBeenCalled();
+    expect(removeAttributeSpy).toHaveBeenCalled();
+  });
+
+  it('will not allow Enter key event to go through while `readonly` attribute is present', async () => {
+    customRender(<Input data-testid="mysearch" />, {
+      search: { pipeline: eventTrackingPipeline },
+    });
+    const input = screen.getByTestId<HTMLInputElement>('mysearch');
+    const setAttributeSpy = jest.spyOn(input, 'setAttribute');
+    const removeAttributeSpy = jest.spyOn(input, 'removeAttribute');
+
+    input.focus();
+    // Multiple enters in quick succession
+    user.keyboard('television{Enter}{Enter}{Enter}');
+
+    await waitFor(() => expect(input.attributes.getNamedItem('readonly')?.value).toBe(''));
+    await waitFor(() => expect(input.attributes.getNamedItem('readonly')).toBeNull());
+
+    expect(setAttributeSpy).toHaveBeenCalledTimes(1);
+    expect(removeAttributeSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -162,12 +162,13 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
 
   const onKeyDownMemoized = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const input = e.target as HTMLInputElement;
       const { value } = e.currentTarget;
-      if (e.key === 'Enter') {
-        const closestForm = (e.target as HTMLInputElement).closest('form');
-        // Blur input to avoid Enter spamming, but only if the input is not wrapped by any form, otherwise the submit event won't be triggered
+      if (e.key === 'Enter' && !input.hasAttribute('readonly')) {
+        const closestForm = input.closest('form');
+        // Set input to readonly, but only if the input is not wrapped by any form, otherwise the submit event won't be triggered
         if (closestForm === null) {
-          (e.target as HTMLInputElement).setAttribute('readonly', '');
+          input.setAttribute('readonly', '');
         }
         if (['typeahead', 'suggestions', 'standard'].includes(mode)) {
           if (!retainFilters) {

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -167,7 +167,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
         const closestForm = (e.target as HTMLInputElement).closest('form');
         // Blur input to avoid Enter spamming, but only if the input is not wrapped by any form, otherwise the submit event won't be triggered
         if (closestForm === null) {
-          (e.target as HTMLInputElement).blur();
+          (e.target as HTMLInputElement).setAttribute('readonly', '');
         }
         if (['typeahead', 'suggestions', 'standard'].includes(mode)) {
           if (!retainFilters) {
@@ -227,6 +227,12 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
       window.clearTimeout(searchDebounceRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (!searching && localRef.current) {
+      localRef.current.removeAttribute('readonly');
+    }
+  }, [searching]);
 
   return (
     <Combobox


### PR DESCRIPTION
This PR removes the blur behavior after the user presses enter because it doesn't allow them to search again immediately. Instead, a `readonly` attribute is added to preserve the focus while still preventing the user from repeatedly spamming enter key, after a search is done the attribute is removed.

Credit goes to @JasonBerry for the solution idea.