### PR TITLE
fix: product price null as return value

### DIFF
--- a/.changeset/brown-rings-greet.md
+++ b/.changeset/brown-rings-greet.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Fix the productPrice sometimes being null as return value, this will break custom result template or require the user to perform an additional check before rendering

--- a/packages/search-ui/src/Results/components/Result/index.tsx
+++ b/packages/search-ui/src/Results/components/Result/index.tsx
@@ -144,10 +144,10 @@ const Result = React.memo(
       return (
         <Box css={styles.priceContainer}>
           <Text css={styles.price} className={priceClassName} disableDefaultStyles={disableDefaultStyles}>
-            {productPrice?.displayPrice}
+            {productPrice.displayPrice}
           </Text>
 
-          {productPrice?.originalPrice && (
+          {productPrice.originalPrice && (
             <Text
               css={styles.originalPrice}
               className={originalPriceClassName}

--- a/packages/search-ui/src/Results/useRenderPrice.test.ts
+++ b/packages/search-ui/src/Results/useRenderPrice.test.ts
@@ -1,0 +1,41 @@
+import { ResultValues } from '@sajari/react-hooks';
+
+import { useRenderPrice, UseRenderPriceInput, UseRenderPriceOutput } from './useRenderPrice';
+
+const defaultValues: ResultValues = {
+  _id: 'random-id',
+  title: 'random-title',
+  url: 'random-url',
+};
+
+test.each<[UseRenderPriceInput, UseRenderPriceOutput]>([
+  [{ onSale: false, values: defaultValues, currency: 'USD' }, { displayPrice: '' }],
+  [{ onSale: false, values: { ...defaultValues, price: '10.99' }, currency: 'USD' }, { displayPrice: '$10.99' }],
+  [{ onSale: true, values: { ...defaultValues, price: '11.99' }, currency: 'USD' }, { displayPrice: '$11.99' }],
+  [
+    { onSale: true, values: { ...defaultValues, price: '8.99', originalPrice: '11.99' }, currency: 'USD' },
+    { displayPrice: '$8.99', originalPrice: '$11.99' },
+  ],
+  [
+    { onSale: true, values: { ...defaultValues, price: '11.99', salePrice: '8.99' }, currency: 'USD' },
+    { displayPrice: '$11.99' },
+  ],
+  [
+    {
+      onSale: true,
+      values: { ...defaultValues, price: '8.99', originalPrice: '11.99', salePrice: '8.99' },
+      currency: 'AUD',
+    },
+    { displayPrice: 'A$8.99', originalPrice: 'A$11.99' },
+  ],
+  [
+    {
+      onSale: true,
+      values: { ...defaultValues, price: '100000', originalPrice: '120000', salePrice: '100000' },
+      currency: 'VND',
+    },
+    { displayPrice: '₫100,000', originalPrice: '₫120,000' },
+  ],
+])('useRenderPrice(%o)', (input, output) => {
+  expect(useRenderPrice(input)).toEqual(output);
+});

--- a/packages/search-ui/src/Results/useRenderPrice.ts
+++ b/packages/search-ui/src/Results/useRenderPrice.ts
@@ -1,4 +1,4 @@
-import { formatPrice, isArray, isEmpty } from '@sajari/react-sdk-utils';
+import { formatPrice, isArray, isEmpty, isNullOrUndefined } from '@sajari/react-sdk-utils';
 
 import type { ResultValues } from './types';
 
@@ -13,7 +13,7 @@ type Input = {
 export type UseRenderPriceOutput = {
   displayPrice: string;
   originalPrice?: string;
-} | null;
+};
 
 export function useRenderPrice({
   values,
@@ -26,7 +26,20 @@ export function useRenderPrice({
   let price = priceProp;
   let dataOriginalPrice = originalPriceProp;
 
-  if (isEmpty(price) || isEmpty(priceProp) || isEmpty(originalPriceProp)) return null;
+  if (isEmpty(price) || isEmpty(priceProp) || isEmpty(originalPriceProp)) {
+    const nonEmptyPrice = [priceProp, originalPriceProp].find((p) => !isEmpty(p));
+
+    // If everything is empty then just return empty string
+    if (isNullOrUndefined(nonEmptyPrice)) {
+      return {
+        displayPrice: '',
+      };
+    }
+
+    return {
+      displayPrice: formatPrice(nonEmptyPrice, { language, currency }),
+    };
+  }
 
   const hasVariantImages = isArray(price[0]);
 
@@ -35,7 +48,11 @@ export function useRenderPrice({
     dataOriginalPrice = originalPriceProp.slice(1);
   }
   const activePrice = isArray(price) ? price[activeImageIndex] ?? price : price;
-  if (isEmpty(activePrice)) return null;
+  if (isEmpty(activePrice)) {
+    return {
+      displayPrice: '',
+    };
+  }
   let displayPrice: string;
   let originalPrice: string | undefined;
 

--- a/packages/search-ui/src/Results/useRenderPrice.ts
+++ b/packages/search-ui/src/Results/useRenderPrice.ts
@@ -1,8 +1,9 @@
+// TODO(tuand): rename this into something else (current name is confusing - this is not a hook)
 import { formatPrice, isArray, isEmpty, isNullOrUndefined } from '@sajari/react-sdk-utils';
 
 import type { ResultValues } from './types';
 
-type Input = {
+export type UseRenderPriceInput = {
   activeImageIndex?: number;
   values: ResultValues;
   onSale: boolean;
@@ -15,13 +16,17 @@ export type UseRenderPriceOutput = {
   originalPrice?: string;
 };
 
+const defaultReturnValue: UseRenderPriceOutput = {
+  displayPrice: '',
+};
+
 export function useRenderPrice({
   values,
   activeImageIndex = 0,
   onSale,
   currency,
   language,
-}: Input): UseRenderPriceOutput {
+}: UseRenderPriceInput): UseRenderPriceOutput {
   const { price: priceProp, salePrice, originalPrice: originalPriceProp } = values;
   let price = priceProp;
   let dataOriginalPrice = originalPriceProp;
@@ -31,9 +36,7 @@ export function useRenderPrice({
 
     // If everything is empty then just return empty string
     if (isNullOrUndefined(nonEmptyPrice)) {
-      return {
-        displayPrice: '',
-      };
+      return defaultReturnValue;
     }
 
     return {
@@ -49,9 +52,7 @@ export function useRenderPrice({
   }
   const activePrice = isArray(price) ? price[activeImageIndex] ?? price : price;
   if (isEmpty(activePrice)) {
-    return {
-      displayPrice: '',
-    };
+    return defaultReturnValue;
   }
   let displayPrice: string;
   let originalPrice: string | undefined;


### PR DESCRIPTION
## Problem
Currently, the `useRenderPrice` hook return the value `null` in some cases, this is not a problem with our standard `Result` component because we already perform checks before rendering. However, this will potentially break in result template mode because users wouldn't expect `productPrice` to be null (maybe it's not too obvious/not documented somewhere)

## The fix
Instead of returning null in those cases, we return the same object shape but with an empty string, this will have the same effect as if the user would have to write a check before rendering in the template code themselves

