### PR TITLE
fix: update mergeBannersWithResults to handle edge case

### DIFF
--- a/.changeset/friendly-walls-taste.md
+++ b/.changeset/friendly-walls-taste.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Fix the output of `mergeBannersWithResults` will contain `undefined` value if there is a banner having a position being greater than the total number of banners and results. The `undefined` value will cause the check of `isBanner` method to break and cause the app to crash.

--- a/packages/search-ui/src/Results/utils.test.ts
+++ b/packages/search-ui/src/Results/utils.test.ts
@@ -156,6 +156,9 @@ test.each<[{ position: number }[], any[], any[]]>([
     [1, 2, 3, 4, 5],
     [{ position: 1 }, { position: 1 }, { position: 1 }, { position: 4 }, 1, 2, 3, 4, 5],
   ],
+  [[{ position: 1 }, { position: 3 }], [], [{ position: 1 }, { position: 3 }]],
+  [[{ position: 1 }, { position: 3 }, { position: 10 }], [1], [{ position: 1 }, 1, { position: 3 }, { position: 10 }]],
+  [[{ position: 1 }, { position: 1 }, { position: 10 }], [1], [{ position: 1 }, { position: 1 }, 1, { position: 10 }]],
 ])('mergeBannersWithResults(%o)', (banners, results, expected) => {
   expect(mergeBannersWithResults(banners, results)).toStrictEqual(expected);
 });

--- a/packages/search-ui/src/Results/utils.ts
+++ b/packages/search-ui/src/Results/utils.ts
@@ -22,8 +22,15 @@ export function mergeBannersWithResults<T = any>(banners: Banner[], results: T[]
       list.push(sortedBanners[currentBannerIndex]);
       currentBannerIndex += 1;
     } else {
-      list.push(results[currentResultIndex]);
-      currentResultIndex += 1;
+      const addedResult = results[currentResultIndex];
+      const addedBanner = sortedBanners[currentBannerIndex];
+      if (addedResult) {
+        list.push(results[currentResultIndex]);
+        currentResultIndex += 1;
+      } else if (addedBanner) {
+        list.push(addedBanner);
+        currentBannerIndex += 1;
+      }
     }
     count += 1;
   }


### PR DESCRIPTION
Fix the output of `mergeBannersWithResults` will contain `undefined` value if there is a banner having a position greater than the total number of the combination between banners and results. The `undefined` value will cause the check of `isBanner` method to break and crash the app. 