### PR TITLE
fix: different height of typeahead

### DIFF
--- a/.changeset/heavy-beers-end.md
+++ b/.changeset/heavy-beers-end.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-components': patch
+---
+
+Fix the different height of typeahead text

--- a/packages/components/src/Combobox/styles.ts
+++ b/packages/components/src/Combobox/styles.ts
@@ -110,7 +110,7 @@ export function useComboboxStyles(props: UseComboboxStylesProps) {
     iconContainerRight: [...iconContainerStyles, tw`right-0`],
     input: [
       tw`form-input`,
-      tw`absolute inset-0 w-full h-full bg-transparent border-0 focus:border-0 outline-none focus:outline-none shadow-none focus:shadow-none font-inherit m-0 p-0 box-border`,
+      tw`absolute inset-0 w-full min-h-full bg-transparent border-0 focus:border-0 outline-none focus:outline-none shadow-none focus:shadow-none font-inherit m-0 p-0 box-border`,
       inputStyles,
       ` &::-ms-clear,
         &::-ms-reveal {


### PR DESCRIPTION
## Problem
The actual text vs the typeahead text is not perfectly vertically aligned

## Solution
It seems the `height` property is making the input behave differently somehow so I've removed that and added a `min-height: 100%` as a fallback instead. See vid

### Original (notice the "e" jumping up and down a little bit)
https://user-images.githubusercontent.com/25856620/163996061-f8d295b9-9cca-4d16-9841-32ee93f60fab.mov

### Fixed
https://user-images.githubusercontent.com/25856620/163996124-e7dd028e-f1d7-403c-b140-9383a27e6a47.mov

SF-549