### PR TITLE
fix: support ability to add data-* attrs

### DIFF
--- a/.changeset/cyan-buttons-allow.md
+++ b/.changeset/cyan-buttons-allow.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-components': patch
+'@sajari/react-search-ui': patch
+---
+
+Support the ability to add custom data-\* attributes for components

--- a/packages/components/src/Box/test/Box.test.tsx
+++ b/packages/components/src/Box/test/Box.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '../../test/utils';
+import Box from '..';
+
+describe('Box', () => {
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Box data-testid="box" data-active="false" />);
+    const box = getByTestId('box');
+    expect(box).toBeVisible();
+    expect(box).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/packages/components/src/Button/index.tsx
+++ b/packages/components/src/Button/index.tsx
@@ -57,10 +57,7 @@ const Button = React.forwardRef((props: ButtonProps, ref?: React.Ref<HTMLElement
     hovered,
   });
 
-  const customProps = mergeProps(buttonProps, focusProps, hoverProps, focusRingProps, {
-    role: rest.role,
-    'aria-checked': rest['aria-checked'],
-  });
+  const customProps = mergeProps(buttonProps, focusProps, hoverProps, focusRingProps, rest);
   const styles = getStylesObject({ container: containerStyles }, disableDefaultStyles);
 
   return (

--- a/packages/components/src/Button/test/Button.test.tsx
+++ b/packages/components/src/Button/test/Button.test.tsx
@@ -46,4 +46,16 @@ describe('Button', () => {
     fireEvent.click(button);
     expect(onClickSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(
+      <Button data-testid="button" data-active="false">
+        Click me
+      </Button>,
+    );
+
+    const button = getByTestId('button');
+    expect(button).toBeVisible();
+    expect(button).toHaveAttribute('data-active', 'false');
+  });
 });

--- a/packages/components/src/ButtonGroup/test/ButtonGroup.test.tsx
+++ b/packages/components/src/ButtonGroup/test/ButtonGroup.test.tsx
@@ -50,4 +50,17 @@ describe('ButtonGroup', () => {
 
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(
+      <ButtonGroup data-testid="button-group" data-active="false">
+        <Button>Button</Button>
+        <Button>Button</Button>
+      </ButtonGroup>,
+    );
+
+    const buttonGroup = getByTestId('button-group');
+    expect(buttonGroup).toBeVisible();
+    expect(buttonGroup).toHaveAttribute('data-active', 'false');
+  });
 });

--- a/packages/components/src/Checkbox/test/Checkbox.test.tsx
+++ b/packages/components/src/Checkbox/test/Checkbox.test.tsx
@@ -43,4 +43,11 @@ describe('Checkbox', () => {
     expect(element).not.toBeNull();
     expect(element?.getAttribute('aria-invalid')).toBe('true');
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Checkbox data-testid="checkbox" data-active="false" />);
+    const checkbox = getByTestId('checkbox');
+    expect(checkbox).toBeVisible();
+    expect(checkbox).toHaveAttribute('data-active', 'false');
+  });
 });

--- a/packages/components/src/Combobox/test/Combobox.test.tsx
+++ b/packages/components/src/Combobox/test/Combobox.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '../../test/utils';
+import Combobox from '..';
+
+describe('Combobox', () => {
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Combobox data-testid="combobox" data-active="false" />);
+    const combobox = getByTestId('combobox');
+    expect(combobox).toBeVisible();
+    expect(combobox.tagName).toBe('INPUT');
+    expect(combobox).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/packages/components/src/Heading/test/Heading.test.tsx
+++ b/packages/components/src/Heading/test/Heading.test.tsx
@@ -33,4 +33,11 @@ describe('Heading', () => {
 
     expect(element).toHaveStyleRule('text-overflow', 'ellipsis');
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Heading as="h1" data-testid="heading" data-active="false" />);
+    const heading = getByTestId('heading');
+    expect(heading).toBeVisible();
+    expect(heading).toHaveAttribute('data-active', 'false');
+  });
 });

--- a/packages/components/src/Image/test/Image.test.tsx
+++ b/packages/components/src/Image/test/Image.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '../../test/utils';
+import Image from '..';
+
+describe('Image', () => {
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Image data-testid="image" data-active="false" src="/a.jpeg" />);
+    const image = getByTestId('image');
+    expect(image.tagName).toBe('IMG');
+    expect(image).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/packages/components/src/Label/test/Label.test.tsx
+++ b/packages/components/src/Label/test/Label.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '../../test/utils';
+import Label from '..';
+
+describe('Label', () => {
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Label data-testid="label" data-active="false" htmlFor="el" />);
+    const label = getByTestId('label');
+    expect(label).toBeVisible();
+    expect(label.tagName).toBe('LABEL');
+    expect(label).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/packages/components/src/Link/test/Link.test.tsx
+++ b/packages/components/src/Link/test/Link.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '../../test/utils';
+import Link from '..';
+
+describe('Link', () => {
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Link data-testid="link" data-active="false" href="/" />);
+    const link = getByTestId('link');
+    expect(link).toBeVisible();
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/packages/components/src/Pagination/test/Pagination.test.tsx
+++ b/packages/components/src/Pagination/test/Pagination.test.tsx
@@ -1,3 +1,4 @@
+import { noop } from '@sajari/react-sdk-utils';
 import * as React from 'react';
 
 import { render } from '../../test/utils';
@@ -52,5 +53,21 @@ describe('Pagination', () => {
     expect(getByLabelText('Trang sau')).toBeInTheDocument();
     expect(getByLabelText('Trang 1, trang hiện tại')).toBeInTheDocument();
     expect(getByLabelText('Trang 2')).toBeInTheDocument();
+  });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(
+      <Pagination
+        data-testid="pagination"
+        data-active="false"
+        totalResults={10}
+        resultsPerPage={5}
+        page={1}
+        onChange={noop}
+      />,
+    );
+    const pagination = getByTestId('pagination');
+    expect(pagination).toBeVisible();
+    expect(pagination).toHaveAttribute('data-active', 'false');
   });
 });

--- a/packages/components/src/Radio/test/Radio.test.tsx
+++ b/packages/components/src/Radio/test/Radio.test.tsx
@@ -65,4 +65,11 @@ describe('Radio', () => {
     expect(element).not.toBeNull();
     expect(element?.getAttribute('aria-invalid')).toBe('true');
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Radio data-testid="radio" data-active="false" />);
+    const radio = getByTestId('radio');
+    expect(radio).toBeVisible();
+    expect(radio).toHaveAttribute('data-active', 'false');
+  });
 });

--- a/packages/components/src/RangeInput/test/RangeInput.test.tsx
+++ b/packages/components/src/RangeInput/test/RangeInput.test.tsx
@@ -81,4 +81,14 @@ describe('RangeInput', () => {
     expect(leftSlider.dataset.value).toBe('25');
     expect(onChange).toHaveBeenCalledWith([25, 75]);
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(
+      <RangeInput data-testid="range-input" data-active="false" value={[50, 75]} min={0} max={500} step={25} />,
+    );
+
+    const rangeInput = getByTestId('range-input');
+    expect(rangeInput).toBeVisible();
+    expect(rangeInput).toHaveAttribute('data-active', 'false');
+  });
 });

--- a/packages/components/src/Select/index.tsx
+++ b/packages/components/src/Select/index.tsx
@@ -33,6 +33,7 @@ const Select = React.forwardRef((props: SelectProps, ref?: React.Ref<HTMLDivElem
     dropdownClassName,
     optionClassName,
     downshiftEnvironment: environment,
+    ...rest
   } = props;
 
   const { styles: selectStyles } = useSelectStyles();
@@ -163,7 +164,7 @@ const Select = React.forwardRef((props: SelectProps, ref?: React.Ref<HTMLDivElem
 
   return (
     <SelectContextProvider value={context}>
-      <Box css={[styles.container, stylesProp]} ref={ref} className={className}>
+      <Box css={[styles.container, stylesProp]} ref={ref} className={className} {...rest}>
         {label && (
           <Label visuallyHidden {...getLabelProps()}>
             {label}

--- a/packages/components/src/Select/test/Select.test.tsx
+++ b/packages/components/src/Select/test/Select.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '../../test/utils';
+import Select from '..';
+
+describe('Select', () => {
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Select data-testid="select" data-active="false" />);
+    const select = getByTestId('select');
+    expect(select).toBeVisible();
+    expect(select).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/packages/components/src/Tabs/test/Tabs.test.tsx
+++ b/packages/components/src/Tabs/test/Tabs.test.tsx
@@ -55,4 +55,23 @@ describe('Tabs', () => {
     expect(tabs[1].tabIndex).toBe(0);
     expect(tabPanels[1].textContent).toBe('Are 1, 2, 3');
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(
+      <Tabs data-testid="tabs" data-active="false">
+        <TabList>
+          <Tab data-testid="tab" data-active="false">
+            Red
+          </Tab>
+        </TabList>
+      </Tabs>,
+    );
+    const tabs = getByTestId('tabs');
+    expect(tabs).toBeVisible();
+    expect(tabs).toHaveAttribute('data-active', 'false');
+
+    const tab = getByTestId('tab');
+    expect(tab).toBeVisible();
+    expect(tab).toHaveAttribute('data-active', 'false');
+  });
 });

--- a/packages/components/src/Text/test/Text.test.tsx
+++ b/packages/components/src/Text/test/Text.test.tsx
@@ -27,4 +27,11 @@ describe('Text', () => {
 
     expect(element).toHaveStyleRule('text-overflow', 'ellipsis');
   });
+
+  it('can add custom data-* attributes', () => {
+    const { getByTestId } = render(<Text data-testid="text" data-active="false" />);
+    const text = getByTestId('text');
+    expect(text).toBeVisible();
+    expect(text).toHaveAttribute('data-active', 'false');
+  });
 });


### PR DESCRIPTION
Ensure components from the SDK support additional `data-*` attributes, for example, passing `data-testid` is helpful for writing tests for the components.