### PR TITLE
feat: add ability to pass custom SearchIOAnalytics instance to EventTracking

### DIFF
--- a/.changeset/two-actors-exist.md
+++ b/.changeset/two-actors-exist.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-hooks': minor
+---
+
+feat: add ability to pass custom SearchIOAnalytics instance to EventTracking

--- a/packages/hooks/src/ContextProvider/controllers/tracking/EventTracking.test.ts
+++ b/packages/hooks/src/ContextProvider/controllers/tracking/EventTracking.test.ts
@@ -1,4 +1,4 @@
-import { Client, TrackingType } from '@sajari/sdk-js';
+import { Client, SearchIOAnalytics, TrackingType } from '@sajari/sdk-js';
 
 import { EVENT_TRACKING_RESET } from '../../events';
 import { Response } from '../Response';
@@ -42,6 +42,16 @@ describe('EventTracking', () => {
     expect(eventTracking.searchIOAnalytics.account).toEqual(account);
     expect(eventTracking.searchIOAnalytics.collection).toEqual(collection);
     expect(eventTracking.searchIOAnalytics.endpoint).toEqual(searchIOAnalyticsEndpoint);
+  });
+
+  it('should set a custom analytics instance', () => {
+    const account = 'account-id';
+    const collection = 'collection-id';
+    const searchIOAnalytics = new SearchIOAnalytics(account, collection);
+    const eventTracking = new EventTracking(undefined, undefined, searchIOAnalytics);
+    eventTracking.bootstrap(new Client(account, collection), jest.fn());
+
+    expect(eventTracking.searchIOAnalytics).toBe(searchIOAnalytics);
   });
 
   describe('onQueryResponse', () => {

--- a/packages/hooks/src/ContextProvider/controllers/tracking/EventTracking.ts
+++ b/packages/hooks/src/ContextProvider/controllers/tracking/EventTracking.ts
@@ -8,14 +8,21 @@ import { getTrackingData } from './utils';
 export class EventTracking extends Tracking {
   public searchIOAnalytics: SearchIOAnalytics;
 
+  private searchIOAnalyticsEndpoint?: string;
+
   /**
    * Construct a EventTracking instance.
    * @param field Field to use for event tracking.
    * @param metadata Metadata fields.
    */
-  constructor(field = '_id', metadata = {}, private searchIOAnalyticsEndpoint?: string) {
+  constructor(field = '_id', metadata = {}, searchIOAnalytics?: string | SearchIOAnalytics) {
     super(field);
 
+    if (searchIOAnalytics instanceof SearchIOAnalytics) {
+      this.searchIOAnalytics = searchIOAnalytics;
+    } else {
+      this.searchIOAnalyticsEndpoint = searchIOAnalytics;
+    }
     this.clientTracking = new DefaultSession(TrackingType.Event, this.field, { ...getTrackingData(), ...metadata });
   }
 


### PR DESCRIPTION
This should enable easier ad-hoc event tracking support, like:
```typescript
import { EventTracking, SearchIOAnalytics } from '@sajari/react-hooks';

const account = '1594153711901724220';
const collection = 'bestbuy';
const searchIOAnalytics = new SearchIOAnalytics(account, collection);
const eventTracking = new EventTracking('id', undefined, searchIOAnalytics);
const pipeline = new Pipeline({ account, collection, }, 'query', eventTracking);

// e.g. in add to cart buttons - doesn't require React context, etc
searchIOAnalytics.track('add_to_cart', product.id);
```

In this way the React components share the same `SearchIOAnalytics` instance as wherever else we might need to track events, so the latest `queryId` will be updated by the pipeline query and correctly bound to the events tracked elsewhere.