### PR TITLE
chore: bump hooks version inside search-ui

### DIFF
--- a/.changeset/brave-pants-run.md
+++ b/.changeset/brave-pants-run.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': minor
+---
+
+Bump hooks's version inside react-search-ui package

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@react-aria/utils": "3.5.0",
     "@sajari/react-components": "^1.14.1",
-    "@sajari/react-hooks": "^3.11.0",
+    "@sajari/react-hooks": "^3.12.0",
     "@sajari/react-sdk-utils": "^1.6.4",
     "dayjs": "^1.10.5",
     "i18next": "19.8.7",


### PR DESCRIPTION
Bump the version of `react-hooks` inside `react-search-ui`