### PR TITLE
fix: hide filters with only one option

### DIFF
--- a/.changeset/poor-penguins-fry.md
+++ b/.changeset/poor-penguins-fry.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+fix: hide filters with only one option

--- a/packages/search-ui/src/Filter/ColorFilter.tsx
+++ b/packages/search-ui/src/Filter/ColorFilter.tsx
@@ -29,7 +29,7 @@ const ColorFilter = ({ name, title }: Omit<ColorFilterProps, 'type'>) => {
     [JSON.stringify(filtered)],
   );
 
-  if (isEmpty(filtered) && isEmpty(selected)) {
+  if ((isEmpty(filtered) && isEmpty(selected)) || filtered.length === 1) {
     return null;
   }
 

--- a/packages/search-ui/src/Filter/ListFilter.tsx
+++ b/packages/search-ui/src/Filter/ListFilter.tsx
@@ -150,7 +150,7 @@ const ListFilter = (props: Omit<ListFilterProps, 'type'>) => {
     setQuery(value || '');
   }, []);
 
-  if (isEmpty(options) && isEmpty(selected)) {
+  if ((isEmpty(options) && isEmpty(selected)) || options.length === 1) {
     return null;
   }
 

--- a/packages/search-ui/src/Filter/SelectFilter.tsx
+++ b/packages/search-ui/src/Filter/SelectFilter.tsx
@@ -32,7 +32,7 @@ const SelectFilter = (props: Omit<SelectFilterProps, 'type'>) => {
   const { disableDefaultStyles = false, customClassNames, currency, downshiftEnvironment } = useSearchUIContext();
   const { t } = useTranslation('filter');
 
-  if (isEmpty(options) && isEmpty(selected)) {
+  if ((isEmpty(options) && isEmpty(selected)) || options.length === 1) {
     return null;
   }
 

--- a/packages/search-ui/src/Filter/TabFilter.tsx
+++ b/packages/search-ui/src/Filter/TabFilter.tsx
@@ -29,7 +29,7 @@ const TabFilter = (props: Omit<TabFilterProps, 'type'>) => {
   const sliced = limit && options.length > limit ? options.slice(0, limit) : options;
   const { disableDefaultStyles = false, customClassNames, currency, language } = useSearchUIContext();
 
-  if (isEmpty(sliced)) {
+  if (isEmpty(sliced) || sliced.length === 1) {
     return null;
   }
 


### PR DESCRIPTION
[SF-575](https://search-io.atlassian.net/jira/software/projects/SF/boards/29?selectedIssue=SF-575)
___
Noting that showing filters that only have one option seems to have been a conscious decision in the past. Refer to [this commit]( https://github.com/sajari/sdk-react/commit/1e6194089ccd86f5ddc9c872c9710ca789960617). 