### PR TITLE
fix: support custom attrs for Filter component

### DIFF
--- a/.changeset/eighty-planes-applaud.md
+++ b/.changeset/eighty-planes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Support custom attributes for Filter component

--- a/packages/search-ui/src/Filter/Box.tsx
+++ b/packages/search-ui/src/Filter/Box.tsx
@@ -1,19 +1,22 @@
 import { Box as CoreBox } from '@sajari/react-components';
+import classnames from 'classnames';
 import * as React from 'react';
 
 import { useSearchUIContext } from '../ContextProvider';
 import Header from './Header';
 import { BoxProps } from './types';
 
-const Box = React.forwardRef(({ children, ...headerProps }: BoxProps, ref: React.Ref<HTMLDivElement>) => {
-  const { customClassNames } = useSearchUIContext();
+const Box = React.forwardRef(
+  ({ children, name, onReset, showReset, title, className, ...rest }: BoxProps, ref: React.Ref<HTMLDivElement>) => {
+    const { customClassNames } = useSearchUIContext();
 
-  return (
-    <CoreBox ref={ref} className={customClassNames.filter?.box}>
-      <Header {...headerProps} />
-      {children}
-    </CoreBox>
-  );
-});
+    return (
+      <CoreBox ref={ref} className={classnames(customClassNames.filter?.box, className)} {...rest}>
+        <Header name={name} onReset={onReset} showReset={showReset} title={title} />
+        {children}
+      </CoreBox>
+    );
+  },
+);
 
 export default Box;

--- a/packages/search-ui/src/Filter/ColorFilter.tsx
+++ b/packages/search-ui/src/Filter/ColorFilter.tsx
@@ -10,7 +10,7 @@ import { capitalize } from './utils';
 
 const { colorKeys } = Swatch;
 
-const ColorFilter = ({ name, title }: Omit<ColorFilterProps, 'type'>) => {
+const ColorFilter = ({ name, title, ...rest }: Omit<ColorFilterProps, 'type'>) => {
   const { options, selected, setSelected, reset, showReset } = useFilter(name);
   const { customClassNames, disableDefaultStyles = false } = useSearchUIContext();
   const optionKeys = useMemo(() => options.map((o) => o.label), [JSON.stringify(options)]);
@@ -34,7 +34,7 @@ const ColorFilter = ({ name, title }: Omit<ColorFilterProps, 'type'>) => {
   }
 
   return (
-    <Box title={title} showReset={showReset} onReset={reset}>
+    <Box title={title} showReset={showReset} onReset={reset} {...rest}>
       <Swatch
         checkedColors={selected}
         onChange={setSelected}

--- a/packages/search-ui/src/Filter/ListFilter.tsx
+++ b/packages/search-ui/src/Filter/ListFilter.tsx
@@ -26,6 +26,7 @@ const ListFilter = (props: Omit<ListFilterProps, 'type'>) => {
     excludes,
     includes,
     prefixFilter,
+    ...rest
   } = props;
 
   const filterContainerId = `list-${name}`;
@@ -155,7 +156,7 @@ const ListFilter = (props: Omit<ListFilterProps, 'type'>) => {
   }
 
   return (
-    <Box title={title} name={name} showReset={showReset} onReset={reset}>
+    <Box title={title} name={name} showReset={showReset} onReset={reset} {...rest}>
       {searchable ? (
         <CoreBox css={styles.searchWrapper}>
           <Combobox

--- a/packages/search-ui/src/Filter/RangeFilter.tsx
+++ b/packages/search-ui/src/Filter/RangeFilter.tsx
@@ -8,7 +8,7 @@ import { RangeFilterProps } from './types';
 import { getHeaderId } from './utils';
 
 const RangeFilter = (props: Omit<RangeFilterProps, 'type' | 'step'>) => {
-  const { name, title, format, showInputs, steps, tick, ticks } = props;
+  const { name, title, format, showInputs, steps, tick, ticks, ...rest } = props;
   const { min, max, range, setRange, reset, showReset, step } = useRangeFilter(name);
   const { disableDefaultStyles = false, customClassNames, currency, language } = useSearchUIContext();
 
@@ -17,7 +17,7 @@ const RangeFilter = (props: Omit<RangeFilterProps, 'type' | 'step'>) => {
   }
 
   return (
-    <Box title={title} name={name} showReset={showReset} onReset={reset}>
+    <Box title={title} name={name} showReset={showReset} onReset={reset} {...rest}>
       <RangeInput
         language={language}
         format={format}

--- a/packages/search-ui/src/Filter/RatingFilter.tsx
+++ b/packages/search-ui/src/Filter/RatingFilter.tsx
@@ -5,7 +5,7 @@ import { useSearchUIContext } from '../ContextProvider';
 import ListFilter from './ListFilter';
 import { RatingFilterProps } from './types';
 
-const RatingFilter = ({ name, title, hideCount, ratingMax }: Omit<RatingFilterProps, 'type'>) => {
+const RatingFilter = ({ name, title, hideCount, ratingMax, ...rest }: Omit<RatingFilterProps, 'type'>) => {
   const { ratingMax: contextRatingMax, disableDefaultStyles, customClassNames } = useSearchUIContext();
 
   const renderRating = useCallback(
@@ -31,6 +31,7 @@ const RatingFilter = ({ name, title, hideCount, ratingMax }: Omit<RatingFilterPr
       pinSelected={false}
       itemRender={renderRating}
       hideCount={hideCount}
+      {...rest}
     />
   );
 };

--- a/packages/search-ui/src/Filter/SelectFilter.tsx
+++ b/packages/search-ui/src/Filter/SelectFilter.tsx
@@ -21,6 +21,7 @@ const SelectFilter = (props: Omit<SelectFilterProps, 'type'>) => {
     excludes,
     includes,
     prefixFilter,
+    ...rest
   } = props;
   const { options, reset, setSelected, selected, multi, showReset } = useFilter(name, {
     sort,
@@ -50,7 +51,7 @@ const SelectFilter = (props: Omit<SelectFilterProps, 'type'>) => {
   };
 
   return (
-    <Box title={title} name={name} showReset={showReset} onReset={reset}>
+    <Box title={title} name={name} showReset={showReset} onReset={reset} {...rest}>
       {!isEmpty(options) && (
         <Select
           multiple={multi}

--- a/packages/search-ui/src/Filter/TabFilter.tsx
+++ b/packages/search-ui/src/Filter/TabFilter.tsx
@@ -1,7 +1,7 @@
 import { Box, Tab, TabList, Tabs } from '@sajari/react-components';
 import { useFilter } from '@sajari/react-hooks';
 import { isEmpty, useTheme } from '@sajari/react-sdk-utils';
-import * as React from 'react';
+import classnames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import tw from 'twin.macro';
 
@@ -22,6 +22,9 @@ const TabFilter = (props: Omit<TabFilterProps, 'type'>) => {
     excludes,
     includes,
     prefixFilter,
+    className,
+    onChange,
+    ...rest
   } = props;
   const { t } = useTranslation('filter');
   const theme = useTheme();
@@ -41,7 +44,8 @@ const TabFilter = (props: Omit<TabFilterProps, 'type'>) => {
       onChange={(index) => setSelected(index !== 0 ? [sliced[index - 1].label] : [])}
       index={selectedIndex < 0 ? 0 : selectedIndex + 1}
       disableDefaultStyles={disableDefaultStyles}
-      className={customClassNames.filter?.tabs?.container}
+      className={classnames(customClassNames.filter?.tabs?.container, className)}
+      {...rest}
     >
       <TabList className={customClassNames.filter?.tabs?.list}>
         <Tab

--- a/packages/search-ui/src/Filter/types.ts
+++ b/packages/search-ui/src/Filter/types.ts
@@ -9,13 +9,14 @@ export interface HeaderProps {
   onReset?: () => void;
 }
 
-export interface BoxProps extends HeaderProps {
+export interface BoxProps
+  extends HeaderProps,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'title' | 'name' | 'onReset'> {
   children: React.ReactNode;
 }
 
-interface BaseFilterProps {
+interface BaseFilterProps extends Omit<BoxProps, 'children' | 'name' | 'onReset'> {
   name: string;
-  title: BoxProps['title'];
 }
 
 export type TextTransform = 'normal-case' | 'uppercase' | 'lowercase' | 'capitalize' | 'capitalize-first-letter';


### PR DESCRIPTION
Add support custom attributes for `Fitler` component. After the change, we can add attributes such as `data-testid` to easily query the component in e2e tests. Usage:

```
<Filter data-testid="rating-filter" type="select" name="category" title="Category" searchable sort="alpha" />
```

![image](https://user-images.githubusercontent.com/12707960/166672383-b10eba90-9c98-42eb-b68d-a8cbc55c690f.png)
