### PR TITLE
fix: multiple API calls due to init data at hook level (WIP)

### DIFF
--- a/packages/hooks/src/ContextProvider/context.ts
+++ b/packages/hooks/src/ContextProvider/context.ts
@@ -1,0 +1,10 @@
+import { createContext } from '@sajari/react-sdk-utils';
+
+import { Context } from './types';
+
+const [Provider, useContext] = createContext<Context>({
+  strict: true,
+  name: 'PipelineContext',
+});
+
+export { Provider, useContext };

--- a/packages/hooks/src/ContextProvider/index.tsx
+++ b/packages/hooks/src/ContextProvider/index.tsx
@@ -3,6 +3,8 @@
 import { createContext, isEmpty, isString } from '@sajari/react-sdk-utils';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import URLStateSync from '../URLStateSync';
+import { initParam } from '../utils/queryParams';
 import { Config, defaultConfig } from './Config';
 import {
   ClickTracking,
@@ -111,6 +113,7 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
   defaultFilter,
   searchOnLoad,
   initialResponse: initialResponseProp,
+  syncURLState,
 }) => {
   const initialResponse = parseResponse(initialResponseProp);
   const [searching, setSearching] = useState(false);
@@ -139,22 +142,13 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
   }
 
   if (!configDone) {
-    const filter = combineFilters(search.filters ?? []);
-    const variablesFilterString = variables.current.get().filter ?? '';
-    const defaultFilterString = defaultFilter?.toString() ?? '';
-
-    variables.current.set({
-      filter: () => {
-        const expression = filter.filter();
-        return [defaultFilterString, variablesFilterString, isEmpty(expression) ? '_id != ""' : expression]
-          .filter(Boolean)
-          .join(' AND ');
-      },
-      countFilters: () => filter.countFilters(),
-      buckets: () => filter.buckets(),
-      count: () => filter.count(),
-      min: () => filter.min(),
-      max: () => filter.max(),
+    initParam({
+      filters: search.filters || [],
+      variables: variables.current,
+      searchState,
+      autocompleteState,
+      defaultFilter,
+      syncURLState,
     });
   }
 
@@ -351,7 +345,12 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
       paginate: handlePaginate,
     } as Context);
 
-  return <Provider value={getContext({ autocomplete: autocompleteState, search: searchState })}>{children}</Provider>;
+  return (
+    <Provider value={getContext({ autocomplete: autocompleteState, search: searchState })}>
+      {syncURLState && <URLStateSync {...(typeof syncURLState !== 'boolean' ? syncURLState : {})} />}
+      {children}
+    </Provider>
+  );
 };
 
 export default ContextProvider;

--- a/packages/hooks/src/ContextProvider/index.tsx
+++ b/packages/hooks/src/ContextProvider/index.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable import/named */
 /* eslint-disable @typescript-eslint/no-shadow */
-import { createContext, isEmpty, isString } from '@sajari/react-sdk-utils';
+import { isEmpty, isString } from '@sajari/react-sdk-utils';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import URLStateSync from '../URLStateSync';
 import { initParam } from '../utils/queryParams';
 import { Config, defaultConfig } from './Config';
+import { Provider, useContext } from './context';
 import {
   ClickTracking,
   EventTracking,
@@ -75,11 +76,6 @@ const valuesUpdatedListener = (variables: Variables, pipeline: Pipeline, prevSta
 
   return updateState(query, pipeline.getResponse(), prevState.config);
 };
-
-const [Provider, useContext] = createContext<Context>({
-  strict: true,
-  name: 'PipelineContext',
-});
 
 const defaultState: ProviderPipelineState = {
   response: null,

--- a/packages/hooks/src/ContextProvider/types.ts
+++ b/packages/hooks/src/ContextProvider/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Redirects } from '@sajari/sdk-js';
 
+import { ParamValue } from '../useQueryParam';
 import { Config } from './Config';
 import { FilterBuilder, Pipeline, RangeFilterBuilder, Response, Variables } from './controllers';
 
@@ -44,12 +45,28 @@ export interface ProviderPipelineState {
   redirects: Redirects;
 }
 
+interface QueryParam {
+  key: string;
+  callback?: (value: string) => void;
+  defaultValue?: ParamValue;
+  value?: ParamValue;
+}
+
+export type SyncURLState =
+  | boolean
+  | {
+      syncParams?: QueryParam[];
+      delay?: number;
+      replace?: boolean;
+    };
+
 export interface SearchProviderValues {
   search: ProviderPipelineConfig;
   autocomplete?: ProviderPipelineConfig;
   defaultFilter?: string;
   searchOnLoad?: boolean;
   initialResponse?: string;
+  syncURLState?: SyncURLState;
 }
 
 export interface PipelineProviderState {

--- a/packages/hooks/src/ContextProvider/types.ts
+++ b/packages/hooks/src/ContextProvider/types.ts
@@ -55,7 +55,7 @@ interface QueryParam {
 export type SyncURLState =
   | boolean
   | {
-      syncParams?: QueryParam[];
+      extendedParams?: QueryParam[];
       delay?: number;
       replace?: boolean;
     };

--- a/packages/hooks/src/URLStateSync/index.tsx
+++ b/packages/hooks/src/URLStateSync/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import { FilterBuilder, Range } from '../ContextProvider';
+import { FilterBuilder, Range } from '../ContextProvider/controllers';
 import useFilter from '../useFilter';
 import useQuery from '../useQuery';
 import useQueryParam from '../useQueryParam';
@@ -116,7 +116,8 @@ const ParamWatcher = ({ delay, replace, queryParam }: ParamWatcherProps) => {
   return null;
 };
 
-const URLStateSync = ({ delay = 500, replace = false, extendedParams = [] }: URLStateSyncProps = {}) => {
+const URLStateSync = (props: URLStateSyncProps = {}) => {
+  const { delay = 500, replace = false, extendedParams = [] } = props;
   const {
     filters: filterBuilders = [],
     config: { qParam = 'q' },

--- a/packages/hooks/src/URLStateSync/index.tsx
+++ b/packages/hooks/src/URLStateSync/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import { FilterBuilder, Range, RangeFilterBuilder } from '../ContextProvider';
+import { FilterBuilder, Range } from '../ContextProvider';
 import useFilter from '../useFilter';
 import useQuery from '../useQuery';
 import useQueryParam from '../useQueryParam';
@@ -8,7 +8,7 @@ import useRangeFilter from '../useRangeFilter';
 import useResultsPerPage from '../useResultsPerPage';
 import useSearchContext from '../useSearchContext';
 import useSorting from '../useSorting';
-import { getSearchParams, isRange, paramToRange, rangeToParam } from '../utils/queryParams';
+import { isRange, paramToRange, rangeToParam } from '../utils/queryParams';
 import { FilterWatcherProps, ParamWatcherProps, QueryParam, RangeFilterWatcherProps, URLStateSyncProps } from './types';
 
 const FilterWatcher = ({ filter, replace, delay }: FilterWatcherProps) => {
@@ -124,7 +124,6 @@ const URLStateSync = ({ delay = 500, replace = false, extendedParams = [] }: URL
   const { query, setQuery } = useQuery();
   const { sorting, setSorting } = useSorting();
   const { resultsPerPage, setResultsPerPage } = useResultsPerPage();
-  const params = getSearchParams();
   const paramWatchers: QueryParam[] = [
     {
       key: qParam,
@@ -146,35 +145,6 @@ const URLStateSync = ({ delay = 500, replace = false, extendedParams = [] }: URL
     },
     ...extendedParams.filter(({ key }) => ![qParam, 'sort', 'show'].includes(key)),
   ];
-
-  useEffect(() => {
-    filterBuilders.forEach((filter) => {
-      if (filter instanceof FilterBuilder) {
-        const key = filter.getField() || filter.getName();
-        const value = params[key] || '';
-        filter.set(value ? value.split(',') : []);
-      } else if (filter instanceof RangeFilterBuilder) {
-        const key = filter.getField() || filter.getName();
-        const value = params[key] || '';
-        const initialRange = paramToRange(value);
-        const limit = (params[`${key}_min_max`] || '').split(':').map(Number) as Range;
-        if (isRange(initialRange)) {
-          filter.set(initialRange as Range);
-        }
-        if (isRange(limit)) {
-          filter.setMin(limit[0]);
-          filter.setMax(limit[1]);
-          // Freeze the state of the filterBuilder to avoid the UI from being overridden at the first response
-          filter.setFrozen(true);
-        }
-      }
-    });
-    paramWatchers.forEach(({ key, callback }) => {
-      if (params[key] && callback) {
-        callback(params[key]);
-      }
-    });
-  }, []);
 
   return (
     <React.Fragment>

--- a/packages/hooks/src/URLStateSync/types.ts
+++ b/packages/hooks/src/URLStateSync/types.ts
@@ -1,4 +1,4 @@
-import { FilterBuilder, RangeFilterBuilder } from '../ContextProvider';
+import { FilterBuilder, RangeFilterBuilder } from '../ContextProvider/controllers';
 import { ParamValue } from '../useQueryParam';
 
 export interface FilterWatcherProps {

--- a/packages/hooks/src/useFilter/index.ts
+++ b/packages/hooks/src/useFilter/index.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { FilterBuilder, useContext } from '../ContextProvider';
+import { useContext } from '../ContextProvider/context';
+import { FilterBuilder } from '../ContextProvider/controllers';
 import { EVENT_SELECTION_UPDATED } from '../ContextProvider/events';
 import { getBucketCount } from '../utils';
 import { FilterItem, SortType } from './types';

--- a/packages/hooks/src/usePagination/index.ts
+++ b/packages/hooks/src/usePagination/index.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { useContext } from '../ContextProvider';
+import { useContext } from '../ContextProvider/context';
 import { UsePaginationResult } from './types';
 
 function usePagination(key: 'search' | 'autocomplete' = 'search'): UsePaginationResult {

--- a/packages/hooks/src/useQuery/index.ts
+++ b/packages/hooks/src/useQuery/index.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { useContext } from '../ContextProvider';
+import { useContext } from '../ContextProvider/context';
 
 function useQuery() {
   const {

--- a/packages/hooks/src/useRangeFilter/index.ts
+++ b/packages/hooks/src/useRangeFilter/index.ts
@@ -1,7 +1,8 @@
 import { isNullOrUndefined } from '@sajari/react-sdk-utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { RangeFilterBuilder, useContext } from '../ContextProvider';
+import { useContext } from '../ContextProvider/context';
+import { RangeFilterBuilder } from '../ContextProvider/controllers';
 import { Range } from '../ContextProvider/controllers/filters/types';
 import { EVENT_RANGE_UPDATED } from '../ContextProvider/events';
 

--- a/packages/hooks/src/useResultsPerPage/index.ts
+++ b/packages/hooks/src/useResultsPerPage/index.ts
@@ -1,7 +1,7 @@
 import { isNumber } from '@sajari/react-sdk-utils';
 import * as React from 'react';
 
-import { useContext } from '../ContextProvider';
+import { useContext } from '../ContextProvider/context';
 import { UseResultsPerPageResult } from './types';
 
 function useResultsPerPage(): UseResultsPerPageResult {

--- a/packages/hooks/src/useSearchContext/index.ts
+++ b/packages/hooks/src/useSearchContext/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { isNullOrUndefined } from '@sajari/react-sdk-utils';
 
-import { useContext } from '../ContextProvider';
+import { useContext } from '../ContextProvider/context';
 import usePagination from '../usePagination';
 import { mapToObject } from '../utils';
 

--- a/packages/hooks/src/useSorting/index.ts
+++ b/packages/hooks/src/useSorting/index.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 
-import { useContext } from '../ContextProvider';
+import { useContext } from '../ContextProvider/context';
 import { UseSortingResult } from './types';
 
 function useSorting(): UseSortingResult {

--- a/packages/hooks/src/utils/queryParams.ts
+++ b/packages/hooks/src/utils/queryParams.ts
@@ -1,6 +1,7 @@
-import { isArray, isNumber, isSSR } from '@sajari/react-sdk-utils';
+import { isArray, isEmpty, isNumber, isSSR } from '@sajari/react-sdk-utils';
 
-import { Range } from '../ContextProvider';
+import { combineFilters, FilterBuilder, Range, RangeFilterBuilder, Variables } from '../ContextProvider/controllers';
+import { ProviderPipelineState, SyncURLState } from '../ContextProvider/types';
 
 export function isRange(value: unknown) {
   return isArray(value) && value.length === 2 && isNumber(value[0]) && isNumber(value[1]);
@@ -24,3 +25,75 @@ export function getSearchParams() {
   });
   return search;
 }
+
+export const initParam = ({
+  filters,
+  variables,
+  searchState,
+  autocompleteState,
+  defaultFilter,
+  syncURLState,
+}: {
+  filters: (FilterBuilder | RangeFilterBuilder)[];
+  variables: Variables;
+  searchState: ProviderPipelineState;
+  autocompleteState: ProviderPipelineState;
+  defaultFilter?: string;
+  syncURLState?: SyncURLState;
+}) => {
+  const params = getSearchParams();
+
+  if (syncURLState) {
+    filters.forEach((filter) => {
+      if (filter instanceof FilterBuilder) {
+        const key = filter.getField() || filter.getName();
+        const value = params[key] || '';
+        filter.set(value ? value.split(',') : []);
+      } else if (filter instanceof RangeFilterBuilder) {
+        const key = filter.getField() || filter.getName();
+        const value = params[key] || '';
+        const initialRange = paramToRange(value);
+        const limit = (params[`${key}_min_max`] || '').split(':').map(Number) as Range;
+        if (isRange(initialRange)) {
+          filter.set(initialRange as Range);
+        }
+        if (isRange(limit)) {
+          filter.setMin(limit[0]);
+          filter.setMax(limit[1]);
+          // Freeze the state of the filterBuilder to avoid the UI from being overridden at the first response
+          filter.setFrozen(true);
+        }
+      }
+    });
+  }
+
+  const filter = combineFilters(filters ?? []);
+  const variablesFilterString = variables.get().filter ?? '';
+  const defaultFilterString = defaultFilter?.toString() ?? '';
+
+  variables.set({
+    filter: () => {
+      const expression = filter.filter();
+      return [defaultFilterString, variablesFilterString, isEmpty(expression) ? '_id != ""' : expression]
+        .filter(Boolean)
+        .join(' AND ');
+    },
+    countFilters: () => filter.countFilters(),
+    buckets: () => filter.buckets(),
+    count: () => filter.count(),
+    min: () => filter.min(),
+    max: () => filter.max(),
+    ...(syncURLState
+      ? {
+          ...(params.show ? { resultsPerPage: params.show } : {}),
+          ...(params.sort ? { sort: params.sort } : {}),
+          ...(params[autocompleteState.config.qParam]
+            ? { [autocompleteState.config.qParam]: params[autocompleteState.config.qParam] }
+            : {}),
+          ...(params[searchState.config.qParam]
+            ? { [searchState.config.qParam]: params[searchState.config.qParam] }
+            : {}),
+        }
+      : {}),
+  });
+};

--- a/packages/hooks/src/utils/response.ts
+++ b/packages/hooks/src/utils/response.ts
@@ -1,7 +1,7 @@
 import { isNumber } from '@sajari/react-sdk-utils';
 import { CountAggregate } from '@sajari/sdk-js';
 
-import { Response } from '../ContextProvider';
+import { Response } from '../ContextProvider/controllers';
 
 export function getBucketCount(response: Response | null, value: string): number | null {
   if (!response || response?.isEmpty()) {

--- a/packages/search-ui/src/ContextProvider/index.tsx
+++ b/packages/search-ui/src/ContextProvider/index.tsx
@@ -27,6 +27,7 @@ const ContextProvider: React.FC<ContextProviderValues> = ({
   customClassNames = {},
   viewType: viewTypeProp = 'list',
   downshiftEnvironment = null,
+  syncURLState,
 }) => {
   const [language, setLanguage] = useState(i18n.language);
   const [viewType, setViewType] = useState<ResultViewType>(viewTypeProp);
@@ -64,6 +65,24 @@ const ContextProvider: React.FC<ContextProviderValues> = ({
         defaultFilter={defaultFilter}
         searchOnLoad={searchOnLoad}
         initialResponse={initialResponse}
+        syncURLState={
+          typeof syncURLState !== 'boolean' && typeof syncURLState !== 'undefined'
+            ? {
+                ...syncURLState,
+                syncParams: [
+                  ...(syncURLState?.syncParams || []),
+                  {
+                    key: 'viewType',
+                    defaultValue: 'list',
+                    callback: (value) => {
+                      setViewType((value as ResultViewType) || 'list');
+                    },
+                    value: viewType,
+                  },
+                ],
+              }
+            : syncURLState
+        }
       >
         <LiveAnnouncer>
           <I18nextProvider i18n={i18n}>


### PR DESCRIPTION
In the existing implementation, the initial data is set at the hook level so that methods like `filter.set` will emit search events to cause multiple API calls after the app is loaded. Instead, the data should be initialized before filters and variables are passed to `SearchProvider`.

**Note: need to fix cycle import issue.**