### PR TITLE
ci: target changeset@v1 to avoid warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           publish: yarn release
           title: Release latest to Production


### PR DESCRIPTION
Resolve [the warning](https://github.com/sajari/sdk-react/runs/6569193910?check_suite_focus=true) for changeset CI: 

> Warning: The workflow file using `changesets/action` is currently using `@master` as the version. This branch has been frozen and deprecated. Please update your workflow to either use `@v1` or a specific commit SHA that is tagged.