### PR TITLE
fix: hook@3.13.1 version bump fail

### DIFF
--- a/.changeset/gentle-games-beg.md
+++ b/.changeset/gentle-games-beg.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+The second attempt to resolve the recent version of the hook package not being released. The version bump doesn't include any changes in the code.


### PR DESCRIPTION
The second attempt to resolve the recent version of the hook package not being released. The version bump doesn't include any changes in the code.