### PR TITLE
fix: initial filter overridden even if URL param is empty

### DIFF
--- a/.changeset/fifty-paws-dream.md
+++ b/.changeset/fifty-paws-dream.md
@@ -1,0 +1,7 @@
+---
+'@sajari/react-hooks': patch
+'sajari-sdk-docs': patch
+'@sajari/react-search-ui': patch
+---
+
+Fix initial value for a filter will be overridden to an empty value if the URL param doesn't exist

--- a/packages/hooks/src/utils/queryParams.test.ts
+++ b/packages/hooks/src/utils/queryParams.test.ts
@@ -1,5 +1,5 @@
-import { Range } from '../ContextProvider';
-import { isRange, paramToRange, rangeToParam } from './queryParams';
+import { FilterBuilder, Range, RangeFilterBuilder, Variables } from '../ContextProvider';
+import { initFiltersFromURLState, initVariableFromURLState, isRange, paramToRange, rangeToParam } from './queryParams';
 
 test.each([
   [undefined, false],
@@ -33,4 +33,142 @@ test.each([
   ['99:42', [99, 42]],
 ])('paramToRange($o)', (input, expectedOutput) => {
   expect(paramToRange(input)).toStrictEqual(expectedOutput);
+});
+
+test.each<
+  [
+    { filters: (FilterBuilder | RangeFilterBuilder)[]; params: Record<string, string> },
+    ((string | number)[] | null)[],
+    (string | number)[][],
+  ]
+>([
+  [
+    {
+      filters: [
+        new FilterBuilder({
+          name: 'brand',
+          field: 'brand',
+        }),
+      ],
+      params: { brand: 'Apple,Samsung' },
+    },
+    [[]],
+    [['Apple', 'Samsung']],
+  ],
+  [
+    {
+      filters: [
+        new FilterBuilder({
+          name: 'brand',
+          field: 'brand',
+        }),
+        new RangeFilterBuilder({
+          name: 'price',
+          field: 'price',
+        }),
+      ],
+      params: { brand: 'Apple,Samsung', price: '1200:4000', price_min_max: '1:5000' },
+    },
+    [[], null],
+    [
+      ['Apple', 'Samsung'],
+      [1200, 4000],
+    ],
+  ],
+  [
+    {
+      filters: [
+        new FilterBuilder({
+          name: 'brand',
+          field: 'brand',
+          initial: ['HP'],
+        }),
+      ],
+      params: { brand: 'Apple,Samsung' },
+    },
+    [['HP']],
+    [['Apple', 'Samsung']],
+  ],
+  [
+    {
+      filters: [
+        new FilterBuilder({
+          name: 'brand',
+          field: 'brand',
+          initial: ['HP'],
+        }),
+      ],
+      params: {},
+    },
+    [['HP']],
+    [['HP']],
+  ],
+  [
+    {
+      filters: [
+        new RangeFilterBuilder({
+          name: 'price',
+          field: 'price',
+          initial: [1000, 4500],
+        }),
+      ],
+      params: { price: '1200:4000', price_min_max: '1:5000' },
+    },
+    [[1000, 4500]],
+    [[1200, 4000]],
+  ],
+  [
+    {
+      filters: [
+        new RangeFilterBuilder({
+          name: 'price',
+          field: 'price',
+          initial: [1000, 4500],
+        }),
+      ],
+      params: {},
+    },
+    [[1000, 4500]],
+    [[1000, 4500]],
+  ],
+])('initFiltersFromURLState($o)', ({ filters, params }, beforeOutput, afterOutput) => {
+  filters.forEach((filter, index) => {
+    expect(filter.get()).toStrictEqual(beforeOutput[index]);
+  });
+  initFiltersFromURLState({ filters, params });
+  filters.forEach((filter, index) => {
+    expect(filter.get()).toStrictEqual(afterOutput[index]);
+  });
+});
+
+test.each<
+  [
+    {
+      variables: Variables;
+      params: Record<string, string>;
+      mappingKeys: { paramKey: string; variableKey: string; defaultValue?: string }[];
+    },
+    Record<string, string>,
+  ]
+>([
+  [
+    {
+      variables: new Variables(),
+      params: { q: 'shoes' },
+      mappingKeys: [
+        { paramKey: 'show', variableKey: 'resultsPerPage', defaultValue: '15' },
+        { paramKey: 'sort', variableKey: 'sort' },
+        { paramKey: 'q', variableKey: 'q', defaultValue: '' },
+      ],
+    },
+    { q: 'shoes', resultsPerPage: '15' },
+  ],
+])('initVariableFromURLState($o, %o, %o)', ({ variables, params, mappingKeys }, expectedOutput) => {
+  mappingKeys.forEach(({ variableKey, defaultValue }) => {
+    expect(variables.get()[variableKey]).toStrictEqual(defaultValue);
+  });
+  initVariableFromURLState({ variables, params, mappingKeys });
+  mappingKeys.forEach(({ variableKey }) => {
+    expect(variables.get()[variableKey]).toStrictEqual(expectedOutput[variableKey]);
+  });
 });

--- a/packages/hooks/src/utils/queryParams.ts
+++ b/packages/hooks/src/utils/queryParams.ts
@@ -35,8 +35,10 @@ export const initFiltersFromURLState = ({
   filters.forEach((filter) => {
     if (filter instanceof FilterBuilder) {
       const key = filter.getField() || filter.getName();
-      const value = params[key] || '';
-      filter.set(value ? value.split(',') : []);
+      const value = params[key];
+      if (value) {
+        filter.set(value.split(','));
+      }
     } else if (filter instanceof RangeFilterBuilder) {
       const key = filter.getField() || filter.getName();
       const value = params[key] || '';


### PR DESCRIPTION
Fix initial value for a filter will be overridden to an empty value if the URL param doesn't exist.