### PR TITLE
feat: add "join" helper to result template

### DIFF
--- a/.changeset/fifty-cycles-walk.md
+++ b/.changeset/fifty-cycles-walk.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': minor
+---
+
+Add "join" helper to result template

--- a/packages/search-ui/src/Results/components/TemplateResults/index.tsx
+++ b/packages/search-ui/src/Results/components/TemplateResults/index.tsx
@@ -4,6 +4,7 @@ import { compile } from 'tempura';
 
 import { useSearchUIContext } from '../../../ContextProvider';
 import { checkValidResultTemplate } from '../../checkValidResultTemplate';
+import blocks from '../../resultTemplateHelpers';
 import { isBanner, mergeBannersWithResults } from '../../utils';
 import BannerItem from '../BannerItem';
 import TemplateResult from '../TemplateResult';
@@ -33,7 +34,7 @@ const TemplateResults = (props: TemplateResultsProps) => {
   keys.push('productPrice');
   keys.push('variantIndex');
   const keysStringified = keys.join(',');
-  const render = useMemo(() => compile(resultTemplate.html, { async: false, props: keys }), [
+  const render = useMemo(() => compile(resultTemplate.html, { async: false, props: keys, blocks }), [
     resultTemplate.html,
     keysStringified,
   ]);

--- a/packages/search-ui/src/Results/resultTemplateHelpers.test.ts
+++ b/packages/search-ui/src/Results/resultTemplateHelpers.test.ts
@@ -1,0 +1,12 @@
+import { join } from './resultTemplateHelpers';
+
+describe('resultTemplateHelpers - join', () => {
+  test.each([
+    [['the', 'lazy', 'fox'], undefined, 'thelazyfox'],
+    [['the', 'lazy', 'fox'], ', ', 'the, lazy, fox'],
+    [[], ', ', ''],
+    [['the'], ', ', 'the'],
+  ])('join(%p, %s) == "%s"', (items, joiner, result) => {
+    expect(join({ items, joiner })).toBe(result);
+  });
+});

--- a/packages/search-ui/src/Results/resultTemplateHelpers.ts
+++ b/packages/search-ui/src/Results/resultTemplateHelpers.ts
@@ -1,0 +1,21 @@
+import { Args, Blocks, Compiler } from 'tempura';
+
+export const join: Compiler = (args: Args) => {
+  const { items, joiner: joinerParam } = args;
+  const joiner = joinerParam ?? '';
+
+  if (items?.length > 1) {
+    return items.join(joiner);
+  }
+  if (items?.length === 1) {
+    return items[0];
+  }
+
+  return '';
+};
+
+const blocks: Blocks = {
+  join,
+};
+
+export default blocks;


### PR DESCRIPTION
## What this PR does
- Add a `join` helper in result template to conveniently render list of items such as categories e.g "Furniture > Chair > Brown Chair"

## API
```hbs
{{#join items=["Furniture", "Chair", "Brown Chair"] joiner=" > "}}
```