### PR TITLE
fix: allow to config URL param keys

### DIFF
--- a/.changeset/short-humans-kiss.md
+++ b/.changeset/short-humans-kiss.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+Allow to config URL param keys

--- a/packages/hooks/src/ContextProvider/index.tsx
+++ b/packages/hooks/src/ContextProvider/index.tsx
@@ -4,7 +4,7 @@ import { getSearchParams, isEmpty, isNumber, isString } from '@sajari/react-sdk-
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import URLStateSync from '../URLStateSync';
-import { defaultURLParamKeys } from '../URLStateSync/Config';
+import { defaultURLParamKeys } from '../URLStateSync/config';
 import { initFiltersFromURLState, initVariableFromURLState } from '../utils/queryParams';
 import { Config, defaultConfig } from './Config';
 import { Provider, useContext } from './context';

--- a/packages/hooks/src/ContextProvider/index.tsx
+++ b/packages/hooks/src/ContextProvider/index.tsx
@@ -4,6 +4,7 @@ import { getSearchParams, isEmpty, isNumber, isString } from '@sajari/react-sdk-
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import URLStateSync from '../URLStateSync';
+import { defaultURLParamKeys } from '../URLStateSync/Config';
 import { initFiltersFromURLState, initVariableFromURLState } from '../utils/queryParams';
 import { Config, defaultConfig } from './Config';
 import { Provider, useContext } from './context';
@@ -142,6 +143,9 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
 
   if (!configDone) {
     if (syncURLState) {
+      const paramKeys =
+        typeof syncURLState === 'boolean' ? defaultURLParamKeys : { ...defaultURLParamKeys, ...syncURLState.paramKeys };
+
       const params = getSearchParams();
       initFiltersFromURLState({
         filters: search.filters || [],
@@ -152,14 +156,14 @@ const ContextProvider: React.FC<SearchProviderValues> = ({
         params,
         mappingKeys: [
           {
-            paramKey: 'show',
+            paramKey: paramKeys.resultsPerPage,
             variableKey: searchState.config.resultsPerPageParam,
             defaultValue: defaultResultsPerPage.current.toString(),
           },
-          { paramKey: 'sort', variableKey: 'sort' },
-          { paramKey: autocompleteState.config.qParam, variableKey: autocompleteState.config.qParam },
-          { paramKey: searchState.config.qParam, variableKey: searchState.config.qParam },
-          { paramKey: searchState.config.pageParam, variableKey: searchState.config.pageParam },
+          { paramKey: paramKeys.sort, variableKey: 'sort' },
+          { paramKey: paramKeys.q, variableKey: autocompleteState.config.qParam },
+          { paramKey: paramKeys.q, variableKey: searchState.config.qParam },
+          { paramKey: paramKeys.page, variableKey: searchState.config.pageParam },
         ],
       });
     }

--- a/packages/hooks/src/ContextProvider/types.ts
+++ b/packages/hooks/src/ContextProvider/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Redirects } from '@sajari/sdk-js';
 
+import { StateSyncURLParamConfig } from '../URLStateSync/Config';
 import { ParamValue } from '../useQueryParam';
 import { Config } from './Config';
 import { FilterBuilder, Pipeline, RangeFilterBuilder, Response, Variables } from './controllers';
@@ -59,6 +60,7 @@ export type SyncURLState =
       extendedParams?: QueryParam[];
       delay?: number;
       replace?: boolean;
+      paramKeys?: Partial<StateSyncURLParamConfig>;
     };
 
 export interface SearchProviderValues {

--- a/packages/hooks/src/ContextProvider/types.ts
+++ b/packages/hooks/src/ContextProvider/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Redirects } from '@sajari/sdk-js';
 
-import { StateSyncURLParamConfig } from '../URLStateSync/Config';
+import { StateSyncURLParamConfig } from '../URLStateSync/config';
 import { ParamValue } from '../useQueryParam';
 import { Config } from './Config';
 import { FilterBuilder, Pipeline, RangeFilterBuilder, Response, Variables } from './controllers';

--- a/packages/hooks/src/URLStateSync/config.ts
+++ b/packages/hooks/src/URLStateSync/config.ts
@@ -1,0 +1,13 @@
+export interface StateSyncURLParamConfig {
+  q: string;
+  resultsPerPage: string;
+  page: string;
+  sort: string;
+}
+
+export const defaultURLParamKeys: StateSyncURLParamConfig = {
+  q: 'q',
+  resultsPerPage: 'show',
+  page: 'page',
+  sort: 'sort',
+};

--- a/packages/hooks/src/URLStateSync/index.tsx
+++ b/packages/hooks/src/URLStateSync/index.tsx
@@ -11,7 +11,7 @@ import useResultsPerPage from '../useResultsPerPage';
 import useSearchContext from '../useSearchContext';
 import useSorting from '../useSorting';
 import { isRange, paramToRange, rangeToParam } from '../utils/queryParams';
-import { defaultURLParamKeys } from './Config';
+import { defaultURLParamKeys } from './config';
 import { FilterWatcherProps, ParamWatcherProps, QueryParam, RangeFilterWatcherProps, URLStateSyncProps } from './types';
 
 const FilterWatcher = ({ filter, replace, delay }: FilterWatcherProps) => {

--- a/packages/hooks/src/URLStateSync/index.tsx
+++ b/packages/hooks/src/URLStateSync/index.tsx
@@ -11,6 +11,7 @@ import useResultsPerPage from '../useResultsPerPage';
 import useSearchContext from '../useSearchContext';
 import useSorting from '../useSorting';
 import { isRange, paramToRange, rangeToParam } from '../utils/queryParams';
+import { defaultURLParamKeys } from './Config';
 import { FilterWatcherProps, ParamWatcherProps, QueryParam, RangeFilterWatcherProps, URLStateSyncProps } from './types';
 
 const FilterWatcher = ({ filter, replace, delay }: FilterWatcherProps) => {
@@ -119,11 +120,9 @@ const ParamWatcher = ({ delay, replace, queryParam }: ParamWatcherProps) => {
 };
 
 const URLStateSync = (props: URLStateSyncProps = {}) => {
-  const { delay = 500, replace = false, extendedParams = [] } = props;
-  const {
-    filters: filterBuilders = [],
-    config: { qParam = 'q', pageParam = 'page' },
-  } = useSearchContext();
+  const { delay = 500, replace = false, extendedParams = [], paramKeys: defaultParamKeysProps } = props;
+  const defaultParamKeys = { ...defaultURLParamKeys, ...defaultParamKeysProps };
+  const { filters: filterBuilders = [] } = useSearchContext();
   const { query, setQuery } = useQuery();
   const { sorting, setSorting } = useSorting();
   const { page, setPage: setPageInner } = usePagination();
@@ -139,17 +138,17 @@ const URLStateSync = (props: URLStateSyncProps = {}) => {
   const { resultsPerPage, setResultsPerPage, defaultResultsPerPage } = useResultsPerPage();
   const paramWatchers: QueryParam[] = [
     {
-      key: qParam,
+      key: defaultParamKeys.q,
       value: query,
       callback: setQuery,
     },
     {
-      key: 'sort',
+      key: defaultParamKeys.sort,
       value: sorting,
       callback: setSorting,
     },
     {
-      key: 'show',
+      key: defaultParamKeys.resultsPerPage,
       value: resultsPerPage,
       defaultValue: defaultResultsPerPage,
       callback: (value) => {
@@ -157,13 +156,15 @@ const URLStateSync = (props: URLStateSyncProps = {}) => {
       },
     },
     {
-      key: pageParam,
+      key: defaultParamKeys.page,
       // Use -1 to remove `page=1` if it's present in the param
       defaultValue: -1,
       value: page === 1 ? -1 : page,
       callback: setPage,
     },
-    ...extendedParams.filter(({ key }) => ![qParam, 'sort', 'show'].includes(key)),
+    ...extendedParams.filter(
+      ({ key }) => ![defaultParamKeys.q, defaultParamKeys.sort, defaultParamKeys.resultsPerPage].includes(key),
+    ),
   ];
 
   return (

--- a/packages/hooks/src/URLStateSync/types.ts
+++ b/packages/hooks/src/URLStateSync/types.ts
@@ -1,6 +1,6 @@
 import { FilterBuilder, RangeFilterBuilder } from '../ContextProvider/controllers';
 import { ParamValue } from '../useQueryParam';
-import { StateSyncURLParamConfig } from './Config';
+import { StateSyncURLParamConfig } from './config';
 
 export interface FilterWatcherProps {
   filter: FilterBuilder;

--- a/packages/hooks/src/URLStateSync/types.ts
+++ b/packages/hooks/src/URLStateSync/types.ts
@@ -1,5 +1,6 @@
 import { FilterBuilder, RangeFilterBuilder } from '../ContextProvider/controllers';
 import { ParamValue } from '../useQueryParam';
+import { StateSyncURLParamConfig } from './Config';
 
 export interface FilterWatcherProps {
   filter: FilterBuilder;
@@ -30,4 +31,5 @@ export interface URLStateSyncProps {
   delay?: number;
   replace?: boolean;
   extendedParams?: QueryParam[];
+  paramKeys?: Partial<StateSyncURLParamConfig>;
 }


### PR DESCRIPTION
Allow changing the URL param keys which previously are hard-coded. For example, `?q=xxx` can be changed to `?query=xxx`. Default mapping keys:

```js
{
  q: 'q',
  resultsPerPage: 'show',
  page: 'page',
  sort: 'sort',
}
```