### PR TITLE
fix: make promo overlays clickable

### DIFF
--- a/.changeset/short-jeans-rule.md
+++ b/.changeset/short-jeans-rule.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': patch
+---
+
+Make promo overlays clickable

--- a/packages/search-ui/src/Results/components/BannerItem/index.tsx
+++ b/packages/search-ui/src/Results/components/BannerItem/index.tsx
@@ -29,22 +29,29 @@ const BannerItem = ({ banner, numberOfCols = 1 }: BannerItemProps) => {
       <Box data-testid="banner-image-container" css={styles.imageContainer}>
         <Link href={targetUrl} css={styles.link} onClick={onClick}>
           <img src={imageUrl} css={styles.image} alt="" loading="lazy" />
+          {(title || description) && (
+            <Box css={styles.textContainer}>
+              {title && (
+                <Heading
+                  as="h2"
+                  className={customClassNames.banners?.heading}
+                  css={[{ color: textColor }, styles.heading]}
+                >
+                  {title}
+                </Heading>
+              )}
+              {description && (
+                <Text
+                  className={customClassNames.banners?.description}
+                  css={[{ color: textColor }, styles.description]}
+                >
+                  {description}
+                </Text>
+              )}
+            </Box>
+          )}
         </Link>
       </Box>
-      {title || description ? (
-        <Box css={styles.textContainer}>
-          {title ? (
-            <Heading as="h2" className={customClassNames.banners?.heading} css={[{ color: textColor }, styles.heading]}>
-              {title}
-            </Heading>
-          ) : null}
-          {description ? (
-            <Text className={customClassNames.banners?.description} css={[{ color: textColor }, styles.description]}>
-              {description}
-            </Text>
-          ) : null}
-        </Box>
-      ) : null}
     </Box>
   );
 };


### PR DESCRIPTION
There's a fair amount of styling simplification and removal of extraneous elements that could be applied but I didn't want to dive into that without storybooks or something that would allow me to play with all the different permutations of displaying results.