### PR TITLE
fix: enable non-case-sensitive redirects from the `Input` component

### DIFF
--- a/.changeset/hip-carrots-count.md
+++ b/.changeset/hip-carrots-count.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-hooks': patch
+'@sajari/react-search-ui': patch
+---
+
+fix: enable non-case-sensitive redirects from the Input component

--- a/packages/hooks/src/useAutocomplete/index.ts
+++ b/packages/hooks/src/useAutocomplete/index.ts
@@ -1,11 +1,13 @@
 import { useContext } from '../ContextProvider';
 
 function useAutocomplete() {
+  // TODO: might not make sense to return the last response from this hook?
   const {
-    autocomplete: { suggestions, search, completion, searching, redirects },
+    autocomplete: { response, suggestions, search, completion, searching, redirects },
   } = useContext();
 
   return {
+    response,
     suggestions,
     search,
     completion,

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -35,6 +35,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
     suggestions,
     redirects,
     searching: autocompleteSearching,
+    response,
   } = useAutocomplete();
   const redirectsRef = useRef(redirects);
   redirectsRef.current = redirects;
@@ -47,6 +48,9 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
   const inputRef = mergeRefs(ref, localRef);
   const lastValue = useRef(query);
   const searchDebounceRef = useRef(0);
+  const qOriginal = response?.getValues()?.get('q.original');
+  const responseQuery = useRef(qOriginal);
+  responseQuery.current = qOriginal;
 
   const searchValue = useCallback(
     (value: string, bypass = false) => {
@@ -174,7 +178,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
           if (!retainFilters) {
             resetFilters();
           }
-          const redirectValue = redirectsRef.current[value];
+          const redirectValue = redirectsRef.current[responseQuery.current ?? value];
           if (!disableRedirects && redirectValue) {
             tracking.onRedirect(redirectValue);
             window.location.assign(redirectValue.token || redirectValue.target);
@@ -183,7 +187,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
             // If we're performing an autocomplete search, wait a tick to recheck redirects before unloading
             e.preventDefault();
             setTimeout(() => {
-              const redirectTarget = redirectsRef.current[value];
+              const redirectTarget = redirectsRef.current[responseQuery.current ?? value];
               if (redirectTarget) {
                 tracking.onRedirect(redirectTarget);
                 window.location.assign(redirectTarget.token || redirectTarget.target);


### PR DESCRIPTION
Currently, adding a `string-lowercase` step to the query/autocomplete pipeline enables the query `Tires` to return the redirect for `tires`, e.g.:
```
redirects: { 
    tires: { 
        id: "abc", 
        target: "https://foo.com",
        token: "123"
    } 
}
```
But the `react-search-ui` `Input` component will only look for redirects based on the raw query `Tires`, not the transformed version `tires`.

Prefer to use the (possibly transformed) query returned from the search response over the raw input query to look up redirects.

[DAU-249](https://algolia.atlassian.net/browse/DAU-249)

___

https://user-images.githubusercontent.com/72959522/216412720-8a8ee086-3656-4516-a60d-e979b2959389.mov
