### PR TITLE
feat: make redirects via the input component case-insensitive

### DIFF
--- a/.changeset/plenty-goats-tan.md
+++ b/.changeset/plenty-goats-tan.md
@@ -1,0 +1,5 @@
+---
+'@sajari/react-search-ui': minor
+---
+
+feat: lowercase search input value when looking for redirects

--- a/.changeset/plenty-goats-tan.md
+++ b/.changeset/plenty-goats-tan.md
@@ -1,5 +1,0 @@
----
-'@sajari/react-search-ui': minor
----
-
-feat: lowercase search input value when looking for redirects

--- a/.changeset/strong-tomatoes-sneeze.md
+++ b/.changeset/strong-tomatoes-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@sajari/react-search-ui': minor
+'sajari-sdk-docs': patch
+---
+
+feat: make redirects case-insensitive for search input component

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
     "react/react-in-jsx-scope": "off",
 
     // TODO: We should re-enable this if we think it's worthwhile
-    "@typescript-eslint/explicit-module-boundary-types": "off"
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "no-plusplus": "off"
   },
   "settings": {
     "react": {

--- a/docs/pages/search-ui/input.mdx
+++ b/docs/pages/search-ui/input.mdx
@@ -133,6 +133,12 @@ function Example() {
 }
 ```
 
+### Note
+
+The `Input` component treats redirects as _case-insensitive_, meaning the user-inputted value `Computer` returns the redirect for the query `computer` and vice versa.
+
+The component does not support the handling of multiple redirects for queries of the same word with varied letter casing. For example, if you have created redirects for each of the queries `computer`, `Computer`, and `COMPUTER`, only one of them is used (dependent upon your browser).
+
 ## Results
 
 ```jsx

--- a/packages/search-ui/src/Input/index.test.tsx
+++ b/packages/search-ui/src/Input/index.test.tsx
@@ -101,6 +101,22 @@ describe('Input', () => {
     });
   });
 
+  it('ignores letter casing of input query on redirect lookup', async () => {
+    const onRedirectSpy = jest.spyOn(eventTrackingPipeline.getTracking(), 'onRedirect');
+    customRender(<Input data-testid="mysearch" mode="suggestions" />, {
+      search: { pipeline: eventTrackingPipeline },
+    });
+    const input = screen.getByTestId('mysearch');
+    input.focus(); // need this else we get TypeError: element.ownerDocument.getSelection is not a function
+    await user.keyboard('ShEeTs');
+    await waitFor(() => expect(input).toHaveTextContent('ShEeTs'));
+    await user.keyboard('{enter}');
+    expect(onRedirectSpy).toHaveBeenCalledWith({
+      ...redirectTarget,
+      token: `https://re.sajari.com/token/${redirectTarget.token}`, // sdk-js prepends the clickTokenURL
+    });
+  });
+
   it('calls onResultClick on results click', async () => {
     const onResultClickSpy = jest.spyOn(eventTrackingPipeline.getTracking(), 'onResultClick');
     customRender(<Input data-testid="mysearch" mode="results" />, {

--- a/packages/search-ui/src/Input/index.test.tsx
+++ b/packages/search-ui/src/Input/index.test.tsx
@@ -49,7 +49,7 @@ const server = setupServer(
         values: {
           q: 'sheets',
           'q.original': 'sheets',
-          'q.suggestions': 'sheets',
+          'q.suggestions': 'suggestion',
         },
         redirects: {
           sheets: redirectTarget,
@@ -92,7 +92,7 @@ describe('Input', () => {
     const input = screen.getByTestId('mysearch');
     input.focus(); // need this else we get TypeError: element.ownerDocument.getSelection is not a function
     await user.keyboard('sheets');
-    await waitFor(() => expect(screen.getByText('sheets')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('suggestion')).toBeInTheDocument());
     await user.keyboard('{enter}');
 
     expect(onRedirectSpy).toHaveBeenCalledWith({
@@ -109,7 +109,7 @@ describe('Input', () => {
     const input = screen.getByTestId('mysearch');
     input.focus(); // need this else we get TypeError: element.ownerDocument.getSelection is not a function
     await user.keyboard('ShEeTs');
-    await waitFor(() => expect(input).toHaveTextContent('ShEeTs'));
+    await waitFor(() => expect(screen.getByText('suggestion')).toBeInTheDocument());
     await user.keyboard('{enter}');
     expect(onRedirectSpy).toHaveBeenCalledWith({
       ...redirectTarget,

--- a/packages/search-ui/src/Input/index.test.tsx
+++ b/packages/search-ui/src/Input/index.test.tsx
@@ -16,6 +16,12 @@ const redirectTarget = {
   token:
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwdXJwb3NlIjoic2VhcmNoIiwiZGVzdGluYXRpb24iOiJodHRwOi8vdGFyZ2V0LmNvbS5hdS9zaGVldHMiLCJ2YWxzIjp7ImNvbGxlY3Rpb24iOlsiYmVzdGJ1eSJdLCJpZGVudGlmaWVyIjpbInJlZGlyZWN0Il0sInByb2plY3QiOlsiMTU5NDE1MzcxMTkwMTcyNDIyMCJdLCJxIjpbInNoZWV0cyJdLCJxLmlkIjpbIjc2ZGJiOGU2LWE3MDctNDU2NC1iYTYxLWY0NjNiYTRhZDdlYSJdLCJxLnVpZCI6WyI3NmRiYjhlNi1hNzA3LTQ1NjQtYmE2MS1mNDYzYmE0YWQ3ZWEwIl0sInJlZGlyZWN0LkNvbmRpdGlvbiI6WyJxIH4gJ3NoZWV0cyciXSwicmVkaXJlY3QuSUQiOlsiMjJ3MFZGdkdWYVlhQ1Jzc0NBUm11YkQ2bGdUIl0sInJlZGlyZWN0LlRhcmdldCI6WyJodHRwOi8vdGFyZ2V0LmNvbS5hdS9zaGVldHMiXX19.BhcAVPB4z9LjlIoV42CUaEW-H0qCJ2JKngs6OGAXTf8',
 };
+const redirectTarget2 = {
+  id: '12w0VFvGVaYaCRssCARmubD6lgA',
+  target: 'http://target.com.au/sheets2',
+  token:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwdXJwb3NlIjoic2VhcmNoIiwiZGVzdGluYXRpb24iOiJodHRwOi8vdGFyZ2V0LmNvbS5hdS9zaGVldHMiLCJ2YWxzIjp7ImNvbGxlY3Rpb24iOlsiYmVzdGJ1eSJdLCJpZGVudGlmaWVyIjpbInJlZGlyZWN0Il0sInByb2plY3QiOlsiMTU5NDE1MzcxMTkwMTcyNDIyMCJdLCJxIjpbInNoZWV0cyJdLCJxLmlkIjpbIjc2ZGJiOGU2LWE3MDctNDU2NC1iYTYxLWY0NjNiYTRhZDdlYSJdLCJxLnVpZCI6WyI3NmRiYjhlNi1hNzA3LTQ1NjQtYmE2MS1mNDYzYmE0YWQ3ZWEwIl0sInJlZGlyZWN0LkNvbmRpdGlvbiI6WyJxIH4gJ3NoZWV0cyciXSwicmVkaXJlY3QuSUQiOlsiMjJ3MFZGdkdWYVlhQ1Jzc0NBUm11YkQ2bGdUIl0sInJlZGlyZWN0LlRhcmdldCI6WyJodHRwOi8vdGFyZ2V0LmNvbS5hdS9zaGVldHMiXX19.BhcAVPB4z9LjlIoV42CUaEW-H0qCJ2JKngs6OGAXTf9',
+};
 const iPhoneResult = {
   values: {
     _id: {
@@ -53,6 +59,7 @@ const server = setupServer(
         },
         redirects: {
           sheets: redirectTarget,
+          Sheets: redirectTarget2,
         },
         searchResponse: {
           reads: '141',
@@ -77,6 +84,7 @@ describe('Input', () => {
   });
   afterEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
     server.resetHandlers();
   });
   afterAll(() => {
@@ -92,28 +100,12 @@ describe('Input', () => {
     const input = screen.getByTestId('mysearch');
     input.focus(); // need this else we get TypeError: element.ownerDocument.getSelection is not a function
     await user.keyboard('sheets');
-    await waitFor(() => expect(screen.getByText('suggestion')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('option')).toHaveTextContent('suggestion'));
     await user.keyboard('{enter}');
 
     expect(onRedirectSpy).toHaveBeenCalledWith({
-      ...redirectTarget,
-      token: `https://re.sajari.com/token/${redirectTarget.token}`, // sdk-js prepends the clickTokenURL
-    });
-  });
-
-  it('ignores letter casing of input query on redirect lookup', async () => {
-    const onRedirectSpy = jest.spyOn(eventTrackingPipeline.getTracking(), 'onRedirect');
-    customRender(<Input data-testid="mysearch" mode="suggestions" />, {
-      search: { pipeline: eventTrackingPipeline },
-    });
-    const input = screen.getByTestId('mysearch');
-    input.focus(); // need this else we get TypeError: element.ownerDocument.getSelection is not a function
-    await user.keyboard('ShEeTs');
-    await waitFor(() => expect(screen.getByText('suggestion')).toBeInTheDocument());
-    await user.keyboard('{enter}');
-    expect(onRedirectSpy).toHaveBeenCalledWith({
-      ...redirectTarget,
-      token: `https://re.sajari.com/token/${redirectTarget.token}`, // sdk-js prepends the clickTokenURL
+      ...redirectTarget2,
+      token: `https://re.sajari.com/token/${redirectTarget2.token}`, // sdk-js appends the clickTokenURL
     });
   });
 
@@ -170,5 +162,33 @@ describe('Input', () => {
 
     await waitFor(() => expect(input.attributes.getNamedItem('readonly')?.value).toBe(''));
     await waitFor(() => expect(input.attributes.getNamedItem('readonly')).toBeNull());
+  });
+});
+
+describe('redirects', () => {
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'warn' });
+  });
+  afterAll(() => {
+    jest.restoreAllMocks();
+    server.close();
+  });
+
+  it('ignores letter casing of input query on redirect lookup', async () => {
+    const onRedirectSpy = jest.spyOn(eventTrackingPipeline.getTracking(), 'onRedirect');
+    customRender(<Input data-testid="mysearch" mode="suggestions" />, {
+      search: { pipeline: eventTrackingPipeline },
+    });
+    const input = screen.getByTestId('mysearch');
+    input.focus(); // need this else we get TypeError: element.ownerDocument.getSelection is not a function
+    await userEvent.type(input, 'ShEeTs');
+    await waitFor(() => expect(screen.getByRole('option')).toHaveTextContent('suggestion'));
+    await userEvent.keyboard('{enter}');
+    await waitFor(() => {
+      expect(onRedirectSpy).toHaveBeenCalledWith({
+        ...redirectTarget2,
+        token: `https://re.sajari.com/token/${redirectTarget2.token}`, // sdk-js appends the clickTokenURL
+      });
+    });
   });
 });

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -10,6 +10,7 @@ import { useSearchUIContext } from '../ContextProvider';
 import { ResultValues } from '../Results/types';
 import mapResultFields from '../utils/mapResultFields';
 import { InputProps } from './types';
+import { lowercaseObjectKeys } from './utils';
 
 const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<HTMLInputElement>) => {
   const { t } = useTranslation('input');
@@ -36,8 +37,9 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
     redirects,
     searching: autocompleteSearching,
   } = useAutocomplete();
-  const redirectsRef = useRef(redirects);
-  redirectsRef.current = redirects;
+  const lowercasedRedirects = lowercaseObjectKeys(redirects);
+  const redirectsRef = useRef(lowercasedRedirects);
+  redirectsRef.current = lowercasedRedirects;
   const { customClassNames, disableDefaultStyles = false, tracking } = useSearchUIContext();
   const { query } = useQuery();
   const [internalSuggestions, setInternalSuggestions] = useState<Array<any>>([]);

--- a/packages/search-ui/src/Input/index.tsx
+++ b/packages/search-ui/src/Input/index.tsx
@@ -174,7 +174,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
           if (!retainFilters) {
             resetFilters();
           }
-          const redirectValue = redirectsRef.current[value];
+          const redirectValue = redirectsRef.current[value.toLowerCase()];
           if (!disableRedirects && redirectValue) {
             tracking.onRedirect(redirectValue);
             window.location.assign(redirectValue.token || redirectValue.target);
@@ -183,7 +183,7 @@ const Input = React.forwardRef((props: InputProps<any>, ref: React.ForwardedRef<
             // If we're performing an autocomplete search, wait a tick to recheck redirects before unloading
             e.preventDefault();
             setTimeout(() => {
-              const redirectTarget = redirectsRef.current[value];
+              const redirectTarget = redirectsRef.current[value.toLowerCase()];
               if (redirectTarget) {
                 tracking.onRedirect(redirectTarget);
                 window.location.assign(redirectTarget.token || redirectTarget.target);

--- a/packages/search-ui/src/Input/utils/index.test.ts
+++ b/packages/search-ui/src/Input/utils/index.test.ts
@@ -5,13 +5,14 @@ test('lowercaseRedirects', () => {
     FoO: { id: '1', target: 'a' },
     BAR: { id: '2', target: 'b' },
     baz: { id: '3', target: 'c' },
-    Test: { id: '4', target: 'd' },
+    test: { id: '4', target: 'd' },
+    Test: { id: '5', target: 'e' },
   };
   const want = {
     foo: { id: '1', target: 'a' },
     bar: { id: '2', target: 'b' },
     baz: { id: '3', target: 'c' },
-    test: { id: '4', target: 'd' },
+    test: { id: '5', target: 'e' },
   };
 
   const got = lowercaseObjectKeys(redirects);

--- a/packages/search-ui/src/Input/utils/index.test.ts
+++ b/packages/search-ui/src/Input/utils/index.test.ts
@@ -1,0 +1,19 @@
+import { lowercaseObjectKeys } from '.';
+
+test('lowercaseRedirects', () => {
+  const redirects = {
+    FoO: { id: '1', target: 'a' },
+    BAR: { id: '2', target: 'b' },
+    baz: { id: '3', target: 'c' },
+    Test: { id: '4', target: 'd' },
+  };
+  const want = {
+    foo: { id: '1', target: 'a' },
+    bar: { id: '2', target: 'b' },
+    baz: { id: '3', target: 'c' },
+    test: { id: '4', target: 'd' },
+  };
+
+  const got = lowercaseObjectKeys(redirects);
+  expect(got).toStrictEqual(want);
+});

--- a/packages/search-ui/src/Input/utils/index.ts
+++ b/packages/search-ui/src/Input/utils/index.ts
@@ -1,0 +1,9 @@
+export function lowercaseObjectKeys(obj: object) {
+  const newObj = {};
+  const keys = Object.keys(obj);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    newObj[key.toLowerCase()] = obj[key];
+  }
+  return newObj;
+}


### PR DESCRIPTION
Assume users don't care about the case-sensitivity of redirects and lowercase all inputs when retrieving redirects, as well as the redirect keys themselves (the queries that trigger the redirects).

[DAU-249](https://algolia.atlassian.net/browse/DAU-249)